### PR TITLE
Convert DynamoDB to use CloudFormation.

### DIFF
--- a/lib/services/dynamodb/dynamodb.yml
+++ b/lib/services/dynamodb/dynamodb.yml
@@ -1,0 +1,75 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Handel-created DynamoDB Table
+
+Parameters:
+  TableName:
+    Description: The name of the Table
+    Type: String
+  PartitionKeyName:
+    Description: The name of the partition key
+    Type: String
+  PartitionKeyType:
+    Description: The type of the partition key
+    Type: String
+    AllowedValues:
+    - S
+    - N
+    - B
+  SortKeyName:
+    Description: The name of the sort key (optional)
+    Type: String
+    Default: none
+  SortKeyType:
+    Description: The type of the sort key (optional)
+    Type: String
+    AllowedValues:
+    - S
+    - N
+    - B
+    - none
+    Default: none
+  ReadCapacityUnits:
+    Description: The number of read capacity units for the table
+    Type: Number
+    Default: 5
+  WriteCapacityUnits:
+    Description: The number of write capacity units for the table
+    Type: Number
+    Default: 5
+
+Conditions: 
+  CreateSortKey: !Equals [ !Ref SortKeyName, none ]
+
+Resources:
+  Table:
+    Type: "AWS::DynamoDB::Table"
+    Properties:
+      AttributeDefinitions:
+        !If
+        - CreateSortKey
+        - - AttributeName: !Ref PartitionKeyName
+            AttributeType: !Ref PartitionKeyType
+        - - AttributeName: !Ref PartitionKeyName
+            AttributeType: !Ref PartitionKeyType
+          - AttributeName: !Ref SortKeyName
+            AttributeType: !Ref SortKeyType
+      KeySchema:
+        !If
+        - CreateSortKey
+        - - AttributeName: !Ref PartitionKeyName
+            KeyType: HASH
+        - - AttributeName: !Ref PartitionKeyName
+            KeyType: HASH
+          - AttributeName: !Ref SortKeyName
+            KeyType: RANGE
+
+      ProvisionedThroughput:
+        ReadCapacityUnits: !Ref ReadCapacityUnits
+        WriteCapacityUnits: !Ref WriteCapacityUnits
+      TableName: !Ref TableName
+
+Outputs:
+  TableName:
+    Description: The name of the Dynamo table
+    Value: !Ref Table

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -1,6 +1,8 @@
 const AWS = require('aws-sdk');
 const winston = require('winston');
 const randtoken = require('rand-token');
+const cloudFormationCalls = require('../../aws/cloudformation-calls');
+const util = require('../../util/util');
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
@@ -67,74 +69,28 @@ function getTable(dynamodb, tableName) {
         });
 }
 
-function waitForTable(dynamodb, tableName) {
-    winston.info("Waiting for table to be in the ACTIVE state");
-    var waitParams = {
-        TableName: tableName
-    };
-    return dynamodb.waitFor('tableExists', waitParams).promise()
-        .then(tableData => {
-            return tableData.Table;
-        });
-}
-
-function createTable(dynamodb, tableName, params) {
-    winston.info(`Creating new DynamoDB table: ${tableName}`)
-
-    let readCapacityUnits = 5; //Default to 5 if none provided by user
-    let writeCapacityUnits = 5; //Default to 5 if none provided by user
-    if(params.provisioned_throughput && params.provisioned_throughput.read_capacity_units) {
-        readCapacityUnits = params.provisioned_throughput.read_capacity_units;
-    }
-    if(params.provisioned_throughput && params.provisioned_throughput.write_capacity_units) {
-        writeCapacityUnits = params.provisioned_throughput.write_capacity_units;
+function getCloudFormationStackParams(stackName, serviceParams) {
+    let stackParams = {
+        TableName: stackName,
+        PartitionKeyName: serviceParams.partition_key.name,
+        PartitionKeyType: keyTypeToAttributeType[serviceParams.partition_key.type]
     }
 
-    let createTableParams = {
-        AttributeDefinitions: [
-            {
-                AttributeName: params.partition_key.name,
-                AttributeType: keyTypeToAttributeType[params.partition_key.type],
-            }
-        ],
-        KeySchema: [
-            {
-                AttributeName: params.partition_key.name,
-                KeyType: "HASH"
-            }
-        ],
-        ProvisionedThroughput: {
-            ReadCapacityUnits: readCapacityUnits,
-            WriteCapacityUnits: writeCapacityUnits
-        },
-        TableName: tableName
-    };
-
-    if(params.sort_key) { //Optional param
-        createTableParams.AttributeDefinitions.push({
-            AttributeName: params.sort_key.name,
-            AttributeType: keyTypeToAttributeType[params.sort_key.type]
-        });
-        createTableParams.KeySchema.push({
-            AttributeName: params.sort_key.name,
-            KeyType: "RANGE"
-        });
+    //Add sort key if provided
+    if(serviceParams.sort_key) {
+        stackParams.SortKeyName = serviceParams.sort_key.name,
+        stackParams.SortKeyType = keyTypeToAttributeType[serviceParams.sort_key.type]
     }
 
-    return dynamodb.createTable(createTableParams).promise()
-        .then(tableData => {
-            return waitForTable(dynamodb, tableName)
-        });
-}
+    //Add provisioned throughput if provided
+    if(serviceParams.provisioned_throughput && serviceParams.provisioned_throughput.read_capacity_units) {
+        stackParams.ReadCapacityUnits = serviceParams.provisioned_throughput.read_capacity_units.toString();
+    }
+    if(serviceParams.provisioned_throughput && serviceParams.provisioned_throughput.write_capacity_units) {
+        stackParams.WriteCapacityUnits = serviceParams.provisioned_throughput.write_capacity_units.toString();
+    }
 
-/**
- * No updates supported on DynamoDB since it makes the table unavailable. All updates must be performed
- *  manually by a developer.
- */
-function updateTable(table) {
-    winston.warn("Updates not suported on DynamoDB");
-    //TODO - Determine on whether an update was requested (different than config) and notify of manual updates
-    return table; //Just return existing table data
+    return cloudFormationCalls.getCfStyleStackParameters(stackParams)
 }
 
 /**
@@ -218,20 +174,30 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
     });
     winston.info(`Deploying dynamodb service: ${ownServiceContext.serviceName}`);
 
-    var params = ownServiceContext.params;
+    var stackName = `${ownServiceContext.appName}-${ownServiceContext.environmentName}-${ownServiceContext.serviceName}`
 
-    var tableName = `${ownServiceContext.appName}-${ownServiceContext.environmentName}-${ownServiceContext.serviceName}`
+    return cloudFormationCalls.getStack(stackName)
+        .then(stack => {
+            if(!stack) { //Create
+                let dynamoTemplate = util.readFileSync(`${__dirname}/DynamoDB.yml`);
+                let stackParams = getCloudFormationStackParams(stackName, ownServiceContext.params);
 
-    return getTable(dynamodb, tableName) //Check if table exists
-        .then(table => {
-            if(!table) { //Create
-                return createTable(dynamodb, tableName, params);
+                //Create the stack and return the table
+                return cloudFormationCalls.createStack(stackName, dynamoTemplate, stackParams)
+                    .then(createdStack => {
+                        return getTable(dynamodb, stackName)
+                            .then(table => {
+                                return getDeployContext(ownServiceContext, table);
+                            });
+                    });
             }
-            else { //Update
-                return updateTable(table);
+            else {
+                winston.warn("Updates not suported on DynamoDB");
+                return getTable(dynamodb, stackName)
+                    .then(table => {
+                        return getDeployContext(ownServiceContext, table);
+                    });
+                
             }
-        })
-        .then(table => {
-            return getDeployContext(ownServiceContext, table);
         });
 }

--- a/lib/services/efs/efs.yml
+++ b/lib/services/efs/efs.yml
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: EFS File System
+Description: Handel-created EFS mount
 
 Parameters:
   FileSystemName:


### PR DESCRIPTION
Using CloudFormation seems to be a lower maintenance cost, and we
can get contributions from multiple people who might not contribute
if it were only being done in code

resolves #20 