### PR TITLE
Add producing/consuming checks to service dependency links.

### DIFF
--- a/bin/handel
+++ b/bin/handel
@@ -89,6 +89,5 @@ handel.deploy(accountConfig, absoluteHandelFilePath, program.environmentsToDeplo
         }
     })
     .catch(err => {
-        winston.warn(`Error during deploy ${err}`);
         winston.warn(err);
     })

--- a/lib/handel.js
+++ b/lib/handel.js
@@ -1,7 +1,6 @@
 const util = require('./util/util');
 const deployOrderCalc = require('./deploy/deploy-order-calc');
 const winston = require('winston');
-const _ = require('lodash');
 const AWS = require('aws-sdk');
 const bindLifecycle = require('./lifecycle/bind');
 const deployLifecycle = require('./lifecycle/deploy');
@@ -21,28 +20,30 @@ function configureAwsSdk(accountConfig) {
     AWS.config.update({region: accountConfig.region});
 }
 
-/**
- * Gets the App Context from the deploy spec file
- */
-function parseEnvironmentContext(handelFilePath, environmentName, deployVersion) {
-    let handelFile = util.readYamlFileSync(handelFilePath);
+function getHandelFileParser(handelFile) {
     let handelFileVersion = handelFile.version;
     let handelFileParserFilename = `./handelfile/parser-v${handelFileVersion}.js`;
     let handelFileParser;
     try {
         handelFileParser = require(handelFileParserFilename);
+        return handelFileParser;
     }
     catch(versionError) {
         winston.error(`Invalid deploy spec version: ${handelFile.version}`);
         return null;
     }
+}
 
+/**
+ * Gets the App Context from the deploy spec file
+ */
+function createEnvironmentContext(handelFile, handelFileParser, environmentName, deployVersion) {
     try {
-        handelFileParser.validateHandelFile(handelFile);
-        return handelFileParser.getEnvironmentContext(handelFile, environmentName, deployVersion);
+        return handelFileParser.createEnvironmentContext(handelFile, environmentName, deployVersion);
     }
     catch(err) {
-        winston.error(`Error while parsing deploy spec: ${err.message}`)
+        winston.error(`Error while parsing deploy spec: ${err.message}`);
+        return null;
     }
 }
 
@@ -74,8 +75,7 @@ function bindAndDeployServices(serviceDeployers, environmentContext, preDeployCo
  * 
  * @returns Promise.<EnvironmentDeployResult>
  */
-function deployEnvironment(accountConfig, serviceDeployers, handelFileFileName, environmentToDeploy, deployVersion) {
-    let environmentContext = parseEnvironmentContext(handelFileFileName, environmentToDeploy, deployVersion);
+function deployEnvironment(accountConfig, serviceDeployers, environmentContext) {
     if(!accountConfig || !environmentContext) {
         return Promise.resolve(new EnvironmentDeployResult("failure", "Invalid configuration"));
     }
@@ -116,10 +116,16 @@ exports.deploy = function(newAccountConfig, handelFilePath, environmentsToDeploy
             //Load all the currently implemented service deployers from the 'services' directory
             let serviceDeployers = util.getServiceDeployers();
 
-            let envDeployPromises = [];
+            //Load Handel file from path and validate it
+            let handelFile = util.readYamlFileSync(handelFilePath);
+            let handelFileParser = getHandelFileParser(handelFile);
+            handelFileParser.validateHandelFile(handelFile, serviceDeployers);
 
+            //Run the deploy on each environment specified
+            let envDeployPromises = [];
             for(let environmentToDeploy of environmentsToDeploy) {
-                envDeployPromises.push(deployEnvironment(accountConfig, serviceDeployers, handelFilePath, environmentToDeploy, deployVersion));
+                let environmentContext = createEnvironmentContext(handelFile, handelFileParser, environmentToDeploy, deployVersion);
+                envDeployPromises.push(deployEnvironment(accountConfig, serviceDeployers, environmentContext));
             }
 
             Promise.all(envDeployPromises)
@@ -128,7 +134,6 @@ exports.deploy = function(newAccountConfig, handelFilePath, environmentsToDeploy
                 });
         }
         catch(err) {
-            winston.warn(err);
             reject(err);
         }
     });

--- a/lib/handelfile/parser-v1.js
+++ b/lib/handelfile/parser-v1.js
@@ -2,63 +2,155 @@ const _ = require('lodash');
 const ServiceContext = require('../datatypes/service-context');
 const EnvironmentContext = require('../datatypes/environment-context');
 
-function checkFieldRequired(handelFile, fieldName) {
-    if (!handelFile[fieldName]) {
-        throw new Error(`Invalid deploy spec: The '${fieldName}' field is required`)
-    }
-}
+const APP_ENV_SERVICE_NAME_REGEX = /^[a-zA-Z0-9-]+$/;
 
-function checkFieldMatchesRegex(handelFile, fieldName) {
-    let appEnvServiceNameRegex = /^[a-zA-Z0-9-]+$/;
-    if(!fieldName.match(appEnvServiceNameRegex)) {
-        throw new Error(`Invalid deploy spec: The '${fieldName}' field may contain only alphanumeric characters and dashes`);
+/**
+ * Checks the top-level name field for correctness.
+ * 
+ * @param {Object} handelFile - The object containing the loaded Handel file
+ * @throws {Error} - The validation error containing a human-readable message about the issue in the Handel file validation.
+ */
+function checkTopLevelFields(handelFile) {
+    //Check that 'version' field matches requirements
+    if(!handelFile.version) {
+        throw new Error(`Invalid Handel file: The top-level 'version' field is required`);
     }
-}
 
-function checkFieldLengthRequirement(handelFile, fieldName, maxLength) {
-    if(handelFile[fieldName].length > maxLength) {
-        throw new Error(`Invalid deploy spec: The '${fieldName}' field may not be greater than ${maxLength} characters`);
+    //Check that 'name' field matches requirements
+    if(!handelFile.name) {
+        throw new Error(`Invalid Handel file: The top-level 'name' field is required`);
+    }
+    if(!handelFile.name.match(APP_ENV_SERVICE_NAME_REGEX)) {
+        throw new Error(`Invalid Handel file: The top-level 'name' field may contain only alphanumeric characters and dashes`);
+    }
+    let maxLengthName = 30;
+    if(handelFile.name.length > maxLengthName) {
+        throw new Error(`Invalid Handel file: The top-level 'name' field may not be greater than ${maxLengthName} characters`);
     }
 }
 
 /**
- * Ensure that the top-level of the deploy spec is valid.
+ * Checks the Handel environment fields for correctness.
  * 
- * This does not check the individual services in the spec, those are handled by the 
- * service deployer themselves.
+ * There are limits and requirements for each of the environment and service names, and this is where those are
+ * checked.
+ * 
+ * Service-specific parameters are not checked here. Instead, they are checked as one of the phases in
+ * the deployer lifecycle, so the deployers themselves implement parameter checking for their service.
+ * 
+ * @param {Object} handelFile - The object containing the loaded Handel file.
+ * @param {Object} serviceDeployers - The object containing the service deployer objects by service type
+ * @throws {Error} - The validation error containing a human-readable message about the issue in the Handel file validation.
  */
-exports.validateHandelFile = function (handelFile) {
-    checkFieldRequired(handelFile, 'version');
-
-    //Name field requirements
-    checkFieldRequired(handelFile, 'name');
-    checkFieldMatchesRegex(handelFile, 'name');
-    checkFieldLengthRequirement(handelFile, 'name', 30);
-    
-    //Environments field requirements
-    checkFieldRequired(handelFile, 'environments');
-    if(handelFile.environments.length === 0) {
-        throw new Error(`Invalid deploy spec: The 'environments' field must contain 1 or more environment definitions`)
+function checkEnvironments(handelFile, serviceDeployers) {
+    //Check that top-level 'environments' field matches requirements
+    if(!handelFile.environments) {
+        throw new Error(`Invalid Handel file: The top-level 'environments' field is required`);
     }
-    for(let envName in handelFile.environments) {
-        checkFieldMatchesRegex(handelFile.environments, envName);
-        checkFieldLengthRequirement(handelFile.environments, envName, 10);
+    if(Object.keys(handelFile.environments).length === 0) {
+        throw new Error(`Invalid Handel file: The 'environments' field must contain 1 or more environment definitions`)
+    }
 
+    //Check that each environment matches requirements
+    for(let envName in handelFile.environments) {
+        console.log(envName);
+        if(!envName.match(APP_ENV_SERVICE_NAME_REGEX)) {
+            throw new Error(`Invalid Handel file: Environment name fields may only contain alphanumeric characters and dashes. You provided the invalid name ${envName}`);
+        }
+        let maxLengthEnv = 10;
+        if(envName.length > maxLengthEnv) {
+            throw new Error(`Invalid Handel file: Environment name fields may not be greater than ${maxLengthEnv} characters. You provided the invalid name ${envName}`);
+        }
+
+        //Check that each service matches overall requirements (service-specific params validation is performed by the services themselves)
         for(let serviceName in handelFile.environments[envName]) {
-            checkFieldMatchesRegex(handelFile.environments[envName], serviceName);
-            checkFieldLengthRequirement(handelFile.environments[envName], serviceName, 20);
+            if(!serviceName.match(APP_ENV_SERVICE_NAME_REGEX)) {
+                throw new Error(`Invalid Handel file: Service name fields may only contain alphanumeric characters and dashes. You provided the invalid name ${serviceName}`);
+            }
+            let maxLengthService = 20;
+            if(serviceName.length > maxLengthService) {
+                throw new Error(`Invalid Handel file: Service name fields may not be greater than ${maxLengthService} characters. You provided the invalid name ${serviceName}`);
+            }
+            let serviceType = handelFile.environments[envName][serviceName].type
+            if(!serviceType) {
+                throw new Error(`Invalid Handel file: Services must declare service type in the 'type' field. Your service '${serviceName}' does not have a type`);
+            }
+
+            //Check that specified service type is supported by Handel
+            if(!serviceDeployers[serviceType]) {
+                throw new Error(`Invalid Handel file: Unsupported service type specified '${serviceType}'`);
+            }
         }
     }
+}
+
+/**
+ * Checks the dependencies of each service to make sure that it is consumable by that service
+ * 
+ * This is accomlished via the "producedDeployOutputTypes" and "consumedDeployOutputTypes" lists from
+ * the deployer contract, where the deployers specify what output types they are able to produce and
+ * consume
+ * 
+ * @param {Object} handelFile - The object containg the loaded Handel file.
+ * @param {Object} serviceDeployers - The object containing the loaded service deployer objects by type.
+ * @throws {Error} - The validation error containing a human-readable message about the issue in the Handel file validation.
+ */
+function checkServiceDependencies(handelFile, serviceDeployers) {
+    for(let envName in handelFile.environments) {
+        let environmentDef = handelFile.environments[envName];
+        for(let serviceName in environmentDef) {
+            let serviceDef = environmentDef[serviceName];
+            if(serviceDef.dependencies) { //Analyze those services that declare dependencies
+                for(let dependentServiceName of serviceDef.dependencies) {
+                    //Make sure the dependent service exists in the environment
+                    if(!environmentDef[dependentServiceName]) {
+                        throw new Error(`Invalid Handel file: You declared a dependency '${dependentServiceName}' in the service '${serviceName}' that doesn't exist`);
+                    }
+                    let dependentServiceDef = environmentDef[dependentServiceName];
+
+                    //Make sure the dependent service produces outputs that the consuming service can consume
+                    let serviceDeployer = serviceDeployers[serviceDef.type];
+                    let dependentServiceDeployer = serviceDeployers[dependentServiceDef.type];
+                    let serviceConsumedOutputs = serviceDeployer.consumedDeployOutputTypes;
+                    let dependentServiceProducedOutputs = dependentServiceDeployer.producedDeployOutputTypes;
+                    //_.difference usage here checks to see if dependentServiceProducedOutputs is a subset of serviceConsumedOutputs
+                    if(_.difference(dependentServiceProducedOutputs, serviceConsumedOutputs).length > 0) {  
+                        throw new Error(`Invalid Handel file: The '${dependentServiceDef.type}' service type is not consumable by the '${serviceDef.type}' service type`);
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+/**
+ * Ensure that the top-level of the Handel file is valid.
+ * 
+ * This does not check the individual services in the file, those are handled by the 
+ * service deployer themselves.
+ * 
+ * @param {Object} handelFile - The object containg the loaded Handel file.
+ * @param {Object} serviceDeployers - The object containing the loaded service deployer objects by type.
+ * @throws {Error} - The validation error containing a human-readable message about the issue in the Handel file validation.
+ */
+exports.validateHandelFile = function (handelFile, serviceDeployers) {
+    checkTopLevelFields(handelFile); //Check that 'name' field matches requirements
+    checkEnvironments(handelFile, serviceDeployers); //Check that environment and services are valid (not all ones will work);
+    checkServiceDependencies(handelFile, serviceDeployers);
 };
 
 /**
- * Given a deploy spec, returns the EnvironmentContext for the requested environment
+ * Given a Handel file, returns the EnvironmentContext for the requested environment.
+ * 
+ * Assume all validation has been done previously, so jsut create the EnvironmentContext
  * 
  * @param {Object} handelFile - The Object representing the provided YAML deploy spec file
  * @param {String} environmentName - The name of the environment in the deploy spec for which we want the EnvironmentContext
  * @param {String} deployVersion - The version of the app being deployed
+ * @returns {EnvironmentContext} - The generated EnvironmentContext from the specified environment in the Handel file
  */
-exports.getEnvironmentContext = function(handelFile, environmentName, deployVersion) {
+exports.createEnvironmentContext = function(handelFile, environmentName, deployVersion) {
     let environmentSpec = handelFile.environments[environmentName];
     if(!environmentSpec) {
         throw new Error(`Can't find the requested environment in the deploy spec: ${environmentName}`)
@@ -67,21 +159,7 @@ exports.getEnvironmentContext = function(handelFile, environmentName, deployVers
     let environmentContext = new EnvironmentContext(handelFile.name, deployVersion, environmentName);
 
     _.forEach(environmentSpec, function(serviceSpec, serviceName) {
-        //TODO - Ensure system names can't be the same
         var serviceType = serviceSpec.type;
-
-        //Verify service type
-        if(!serviceType) {
-            throw new Error(`This service doesn't have a service type specified: ${serviceName}`)
-        }
-        try { 
-            let deployerPath = `../services/${serviceType}`
-            require(deployerPath); //Ok to do sync call inline here since this is initial setup and won't block anyone else
-        }
-        catch(e) {
-            throw new Error(`Invalid or unsupported service type specified: ${serviceType}`);
-        }
-
         var serviceContext = new ServiceContext(handelFile.name, environmentName, serviceName,
                                                 serviceType, deployVersion, serviceSpec);
         environmentContext.serviceContexts[serviceName] = serviceContext;

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -189,3 +189,24 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
             return new DeployContext(ownServiceContext);
         });
 }
+
+/**
+ * The list of output types that this service produces. 
+ * 
+ * If the list is empty, this service cannot be consumed by other resources.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.producedDeployOutputTypes = [];
+
+/**
+ * The list of output types that this service consumes from other dependencies.
+ * 
+ * If the list is empty, this service cannot consume other services.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.consumedDeployOutputTypes = [
+    'environmentVariables',
+    'policies'
+];

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -201,3 +201,24 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
             }
         });
 }
+
+/**
+ * The list of output types that this service produces. 
+ * 
+ * If the list is empty, this service cannot be consumed by other resources.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.producedDeployOutputTypes = [
+    'environmentVariables',
+    'policies'
+];
+
+/**
+ * The list of output types that this service consumes from other dependencies.
+ * 
+ * If the list is empty, this service cannot consume other services.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.consumedDeployOutputTypes = [];

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -146,3 +146,26 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
                 });
         });
 }
+
+/**
+ * The list of output types that this service produces. 
+ * 
+ * If the list is empty, this service cannot be consumed by other resources.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.producedDeployOutputTypes = [];
+
+/**
+ * The list of output types that this service consumes from other dependencies.
+ * 
+ * If the list is empty, this service cannot consume other services.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.consumedDeployOutputTypes = [
+    'environmentVariables',
+    'scripts',
+    'policies',
+    'securityGroups'
+];

--- a/lib/services/efs/index.js
+++ b/lib/services/efs/index.js
@@ -176,3 +176,25 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
             }
         });
 }
+
+/**
+ * The list of output types that this service produces. 
+ * 
+ * If the list is empty, this service cannot be consumed by other resources.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.producedDeployOutputTypes = [
+    'environmentVariables',
+    'scripts',
+    'securityGroups'
+];
+
+/**
+ * The list of output types that this service consumes from other dependencies.
+ * 
+ * If the list is empty, this service cannot consume other services.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.consumedDeployOutputTypes = [];

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -96,11 +96,11 @@ exports.getServiceDeployers = function() {
     let deployers = {};
     
     let servicesPath = path.join(__dirname, '../services')
-    let serviceNames = fs.readdirSync(servicesPath);
-    serviceNames.forEach(serviceName => {
-        let servicePath = `${servicesPath}/${serviceName}`;
-        if(fs.lstatSync(servicePath).isDirectory()) { //Zip directory up into file 
-            deployers[serviceName] = require(servicePath);
+    let serviceTypes = fs.readdirSync(servicesPath);
+    serviceTypes.forEach(serviceType => {
+        let servicePath = `${servicesPath}/${serviceType}`;
+        if(fs.lstatSync(servicePath).isDirectory()) { 
+            deployers[serviceType] = require(servicePath);
         }
     });
 

--- a/test/handelfile/parser-v1-test.js
+++ b/test/handelfile/parser-v1-test.js
@@ -5,11 +5,46 @@ const fs = require('fs');
 const expect = require('chai').expect;
 
 describe('parser-v1', function() {
+    let serviceDeployers = {
+        dynamodb: {
+            producedDeployOutputTypes: [
+                'environmentVariables',
+                'policies'
+            ],
+            consumedDeployOutputTypes: []        
+        },
+        ecs: {
+            producedDeployOutputTypes: [],
+            consumedDeployOutputTypes: [
+                'environmentVariables',
+                'scripts',
+                'policies',
+                'securityGroups'
+            ]
+        },
+        efs: {
+            producedDeployOutputTypes: [
+                'environmentVariables',
+                'scripts',
+                'securityGroups'
+            ],
+            consumedDeployOutputTypes: []
+        },
+        apigateway: {
+            producedDeployOutputTypes: [],
+            consumedDeployOutputTypes: [
+                'environmentVariables',
+                'policies'
+            ]
+        }
+    }
+
+
     describe('validateHandelFile', function() {
         it('should complain about a missing version', function() {
             let handelFile = {}
             try {
-                parserV1.validateHandelFile(handelFile);
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
                 expect(true).to.be.false; //Should not get here
             }
             catch(e) {
@@ -22,11 +57,25 @@ describe('parser-v1', function() {
                 version: 1
             }
             try {
-                parserV1.validateHandelFile(handelFile);
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
                 expect(true).to.be.false; //Should not get here
             }
             catch(e) {
                 expect(e.message).to.include("'name' field is required");
+            }
+        });
+
+        it('should complain about a name field that doesnt match the regex', function() {   
+            let handelFile = {
+                version: 1,
+                name: "some&bad$chars"
+            }
+            try {
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
+                expect(true).to.be.false; //Should not get here
+            }
+            catch(e) {
+                expect(e.message).to.include("'name' field may contain only alphanumeric");
             }
         });
 
@@ -36,7 +85,7 @@ describe('parser-v1', function() {
                 name: "thisfieldiswaytolongofanameanditisgettinglongerandlongerbytheday"
             }
             try {
-                parserV1.validateHandelFile(handelFile);
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
                 expect(true).to.be.false; //Should not get here
             }
             catch(e) {
@@ -50,7 +99,7 @@ describe('parser-v1', function() {
                 name: 'test'
             }
             try {
-                parserV1.validateHandelFile(handelFile);
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
                 expect(true).to.be.false; //Should not get here
             }
             catch(e) {
@@ -62,10 +111,10 @@ describe('parser-v1', function() {
             let handelFile = {
                 version: 1,
                 name: 'test',
-                environments: []
+                environments: {}
             }
             try {
-                parserV1.validateHandelFile(handelFile);
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
                 expect(true).to.be.false; //Should not get here
             }
             catch(e) {
@@ -73,17 +122,162 @@ describe('parser-v1', function() {
             }
         });
 
-        it('should work on a deploy spec that has valid top-level information', function() {
+        it('should complain about an environment name that contains the wrong characters', function() {
             let handelFile = {
                 version: 1,
                 name: 'test',
-                environments: [{}]
+                environments: {
+                    'jk$jk': {}
+                }
             }
-            parserV1.validateHandelFile(handelFile);
+            try {
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
+                expect(true).to.be.false; //Should not get here
+            }
+            catch(e) {
+                expect(e.message).to.include("Environment name fields may only contain alphanumeric");
+            }
+        });
+
+        it('should complain about an environment name that is too long', function() {
+            let handelFile = {
+                version: 1,
+                name: 'test',
+                environments: {
+                    'thisfieldiswaytolongofanameanditisgettinglongerandlongerbytheday': {}
+                }
+            }
+            try {
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
+                expect(true).to.be.false; //Should not get here
+            }
+            catch(e) {
+                expect(e.message).to.include("Environment name fields may not be greater than");
+            }
+        });
+
+        it('should complain about a service name that contains the wrong characters', function() {
+            let handelFile = {
+                version: 1,
+                name: 'test',
+                environments: {
+                    valid: {
+                        'jk$jk': {}
+                    }
+                }
+            }
+            try {
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
+                expect(true).to.be.false; //Should not get here
+            }
+            catch(e) {
+                expect(e.message).to.include("Service name fields may only contain alphanumeric");
+            }
+        });
+
+        it('should complain about a service name that is too long', function() {
+            let handelFile = {
+                version: 1,
+                name: 'test',
+                environments: {
+                    valid: {
+                        'thisfieldiswaytolongofanameanditisgettinglongerandlongerbytheday': {}
+                    }
+                }
+            }
+            try {
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
+                expect(true).to.be.false; //Should not get here
+            }
+            catch(e) {
+                expect(e.message).to.include("Service name fields may not be greater than");
+            }
+        });
+
+        it('should complain about a service that doesnt contain the type field', function() {
+            let handelFile = {
+                version: 1,
+                name: 'test',
+                environments: {
+                    valid: {
+                        valid: {}
+                    }
+                }
+            }
+            try {
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
+                expect(true).to.be.false; //Should not get here
+            }
+            catch(e) {
+                expect(e.message).to.include("Services must declare service type in the 'type' field");
+            }
+        });
+
+        it('should complain if an unsupported service type is specified', function() {
+            let handelFile = {
+                version: 1,
+                name: 'test',
+                environments: {
+                    myenv: {
+                        myunsupportedservice: {
+                            type: 'unsupportedtype'
+                        }
+                    }
+                }
+            }
+            try {
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
+                expect(true).to.be.false; //Should not get here
+            }
+            catch(e) {
+                expect(e.message).to.include("Unsupported service type specified");
+            }
+        });
+
+        it('should complain about a service that depends on a service it cant consume', function() {
+            let handelFile = {
+                version: 1,
+                name: 'test',
+                environments: {
+                    myenv: {
+                        myapigateway: {
+                            type: 'apigateway',
+                            dependencies: [
+                                'myefs'
+                            ]
+                        },
+                        myefs: {
+                            type: 'efs'
+                        }
+                    }
+                }
+            }
+            try {
+                parserV1.validateHandelFile(handelFile, serviceDeployers);
+                expect(true).to.be.false; //Should not get here
+            }
+            catch(e) {
+                expect(e.message).to.include("service type is not consumable");
+            }
+        });
+
+        it('should work on a handel file that has valid top-level information', function() {
+            let handelFile = {
+                version: 1,
+                name: 'test',
+                environments: {
+                    valid: {
+                        valid: {
+                            type: 'dynamodb'
+                        }
+                    }
+                }
+            }
+            parserV1.validateHandelFile(handelFile, serviceDeployers);
         });
     });
 
-    describe('getEnvironmentContext', function() {
+    describe('createEnvironmentContext', function() {
         it("should build the environment context from the deploy spec", function() {
             let handelFile = {
                 version: 1,
@@ -97,53 +291,10 @@ describe('parser-v1', function() {
                     }
                 }
             };
-            let environmentContext = parserV1.getEnvironmentContext(handelFile, "dev", "1");
+            let environmentContext = parserV1.createEnvironmentContext(handelFile, "dev", "1");
             expect(environmentContext.appName).to.equal('test');
             expect(environmentContext.environmentName).to.equal('dev');
             expect(environmentContext.serviceContexts['A'].serviceType).to.equal('dynamodb');
-        });
-
-        it("should throw an error if no service type is specified in any of the services", function() {
-            let handelFile = {
-                version: 1,
-                name: 'test',
-                environments: {
-                    dev: {
-                        A: {
-                            some: 'param'
-                        }
-                    }
-                }
-            };
-            try {
-                let environmentContext = parserV1.getEnvironmentContext(handelFile, "dev", "1");
-                expect(true).to.be.false; //Shouldn't get here
-            }
-            catch(e) {
-                expect(e.message).to.include("This service doesn't have a service type");
-            }
-        });
-
-        it("should throw an error if an unknown service type is specified.", function() {
-            let handelFile = {
-                version: 1,
-                name: 'test',
-                environments: {
-                    dev: {
-                        A: {
-                            type: 'david',
-                            some: 'param'
-                        }
-                    }
-                }
-            };
-            try {
-                let environmentContext = parserV1.getEnvironmentContext(handelFile, "dev", "1");
-                expect(true).to.be.false; //Shouldn't get here
-            }
-            catch(e) {
-                expect(e.message).to.include("Invalid or unsupported service type");
-            }
         });
     });
 });


### PR DESCRIPTION
Previously, we didn't check whether a particular service (like EFS)
was consumable from another service (like API Gateway). Not all
AWS services can be consumed by others, so each service needs to
provide hints about what it produces, as well as what it can
consume. This is provided in the form of output types (such as
environment variables, scripts, etc.), that the service deployer
specifies.

The Handel validation then reads this information from the deployers
as it looks at dependency information, and outputs errors if any
dependencies are specified for incompatible services

Resolves #15 