### PR TITLE
Add initial support for S3

### DIFF
--- a/lib/handel.js
+++ b/lib/handel.js
@@ -101,8 +101,7 @@ function deployEnvironment(accountConfig, serviceDeployers, environmentContext) 
                     return setupEventBindings(serviceDeployers, environmentContext, bindAndDeployResults.deployContexts);
                 })
                 .then(eventBindingResults => {
-                    console.log("EVENT BINDING RESULTS!");
-                    console.log(eventBindingResults);
+                    //TODO - Do something here with the event binding results?
                     return new EnvironmentDeployResult("success");
                 })
                 .catch(err => {

--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -69,3 +69,7 @@ exports.uploadFileToHandelBucket = function(serviceContext, diskFilePath, s3File
             return s3Calls.uploadFile(bucketName, artifactKey, diskFilePath);
         });
 }
+
+exports.getCloudformationStackName = function(serviceContext) {
+    return `${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}`;
+}

--- a/lib/services/ecs/ecs-service.yml
+++ b/lib/services/ecs/ecs-service.yml
@@ -1,6 +1,6 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
-Description: ECS Cluster
+Description: Handel-created ECS Cluster
 Parameters:
   ClusterName:
     Description: Name of the cluster to be created

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -1,54 +1,50 @@
 const winston = require('winston');
-const ec2Calls = require('../../aws/ec2-calls');
-const handlebarsUtils = require('../../util/handlebars-utils');
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
+const ProduceEventsContext = require('../../datatypes/produce-events-context');
 const accountConfig = require('../../util/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployersCommon = require('../deployers-common');
 const util = require('../../util/util');
 
-const EFS_PORT = 2049;
-const EFS_SG_PROTOCOL = "tcp";
-const EFS_PERFORMANCE_MODE_MAP = {
-    "general_purpose": "generalPurpose",
-    "max_io": "maxIO"
+const VERSIONING_PARAM_MAPPING = {
+    enabled: 'Enabled',
+    disabled: 'Suspended'
 }
 
-function getMountScript(fileSystemId, region, mountDir) {
-    let variables = { //TODO - REPLACE THIS WITH SOMETHING ELSE
-        "EFS_FILE_SYSTEM_ID": fileSystemId,
-        "EFS_REGION": region,
-        "EFS_MOUNT_DIR": mountDir
-    }
-    return handlebarsUtils.compileTemplate(`${__dirname}/mount-script-template.sh`, variables)
-        .then(mountScript => {
-            return mountScript;
-        });
-}
-
-function getDeployContext(serviceContext, fileSystemId, region, fileSystemName) {
+function getDeployContext(serviceContext, cfStack) {
+    let bucketName = cloudFormationCalls.getOutput('BucketName', cfStack);
     let deployContext = new DeployContext(serviceContext);
 
-    let mountDir = `/mnt/share/${fileSystemName}`
-    return getMountScript(fileSystemId, region, mountDir)
-        .then(mountScript => {
-            let mountDirEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'MOUNT_DIR');
-            deployContext.environmentVariables[mountDirEnv] = mountDir
-            deployContext.scripts.push(mountScript);
-            return deployContext;
-        });
-}
+    //Env variables to inject into consuming services
+    let bucketNameEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'BUCKET_NAME');
+    deployContext.environmentVariables[bucketNameEnv] = bucketName;
+    let bucketUrlEnv = deployersCommon.getInjectedEnvVarName(serviceContext, "BUCKET_URL");
+    deployContext.environmentVariables[bucketUrlEnv] = `https://${bucketName}.s3.amazonaws.com/`
+    let regionEndpointEnv = deployersCommon.getInjectedEnvVarName(serviceContext, "REGION_ENDPOINT");
+    deployContext.environmentVariables[regionEndpointEnv] = `s3-${accountConfig.region}.amazonaws.com`;
 
-function getFileSystemIdFromStack(stack) {
-    let fileSystemId = cloudFormationCalls.getOutput('EFSFileSystemId', stack);
-    if(fileSystemId) {
-        return fileSystemId;
-    }
-    else {
-        throw new Error("Couldn't find EFS file system ID in CloudFormation stack outputs");
-    }
+    //Need two policies for accessing S3. The first allows you to list the contents of the bucket,
+    // and the second allows you to modify objects in that bucket
+    deployContext.policies.push({
+        "Effect": "Allow",
+        "Action": [
+            "s3:ListBucket"
+        ],
+        "Resource": [`arn:aws:s3:::${bucketName}`]
+    })
+    deployContext.policies.push({
+        "Effect": "Allow",
+        "Action": [
+            "s3:PutObject",
+            "s3:GetObject",
+            "s3:DeleteObject"
+        ],
+        "Resource": [`arn:aws:s3:::${bucketName}/*`]
+    });
+
+    return deployContext;
 }
 
 /**
@@ -60,13 +56,15 @@ function getFileSystemIdFromStack(stack) {
  */
 exports.check = function(serviceContext) {
     let errors = [];
+
     let params = serviceContext.params;
-    let perfModeParam = params['performance_mode']
-    if(perfModeParam) {
-        if(perfModeParam !== 'general_purpose' && perfModeParam !== 'max_io') {
-            errors.push("EFS - 'performance_mode' parameter must be either 'general_purpose' or 'max_io'");
-        }
+    if(!params.bucket_name) {
+        errors.push("S3 - 'bucket_name' parameter is required");
     }
+    if(params.versioning && (params.versioning !== 'enabled' && params.versioning !== 'disabled')) {
+        errors.push("S3 - 'versioning' parameter must be either 'enabled' or 'disabled'");
+    }
+
     return errors;
 }
 
@@ -79,13 +77,8 @@ exports.check = function(serviceContext) {
  * @returns {Promise.<PreDeployContext>} - A Promise of the PreDeployContext results from the pre-deploy
  */
 exports.preDeploy = function(serviceContext) {
-    let sg_name = `${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}-${serviceContext.serviceType}`;
-    return ec2Calls.createSecurityGroupIfNotExists(sg_name, accountConfig['vpc'])
-        .then(securityGroup => {
-            let preDeployContext = new PreDeployContext(serviceContext);
-            preDeployContext.securityGroups.push(securityGroup);
-            return preDeployContext;
-        });
+    //Nothing to do in PreDeploy
+    return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
 
@@ -107,15 +100,8 @@ exports.preDeploy = function(serviceContext) {
  * @returns {Promise.<BindContext>} - A Promise of the BindContext results from the Bind
  */
 exports.bind = function(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    let ownSg = ownPreDeployContext.securityGroups[0];
-    let sourceSg = dependentOfPreDeployContext.securityGroups[0];
-
-    return ec2Calls.addIngressRuleToSgIfNotExists(sourceSg, ownSg, 
-                                                  EFS_SG_PROTOCOL, EFS_PORT, 
-                                                  EFS_PORT, accountConfig['vpc'])
-        .then(efsSecurityGroup => {
-            return new BindContext(ownServiceContext);
-        });
+    //Nothing to do in Bind
+    return Promise.resolve(new BindContext(ownServiceContext));
 }
 
 
@@ -134,45 +120,28 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
 
     return cloudFormationCalls.getStack(stackName)
         .then(stack => {
-            if(!stack) {
-                winston.info(`Creating EFS file system ${stackName}`);
-                let efsParams = ownServiceContext.params;
+            let s3Params = ownServiceContext.params;
+            let s3Template = util.readFileSync(`${__dirname}/s3.yml`);
 
-                //Choose performance mode
-                let performanceMode = "generalPurpose"; //Default
-                if(efsParams.performance_mode) {
-                    performanceMode = EFS_PERFORMANCE_MODE_MAP[efsParams.performance_mode];
-                }
+            let stackParams = {
+                BucketName: s3Params.bucket_name,
+                VersioningStatus: "Suspended"
+            }
+            if(s3Params.versioning) {
+                stackParams.VersioningStatus = VERSIONING_PARAM_MAPPING[s3Params.versioning];
+            }
 
-                //Set up subnets
-                let subnetIds = accountConfig['data_subnets'];
-                let subnetA = subnetIds[0]; //Default to using a single subnet for the ids (if they only provided one)
-                let subnetB = subnetIds[0];
-                if(subnetIds.length > 1) { //Use multiple subnets if provided
-                    subnetB = subnetIds[1]; 
-                }
-
-                //Specify parameters to be passed into stack
-                let stackParameters = {
-                    FileSystemName: stackName,
-                    PerformanceMode: performanceMode,
-                    SecurityGroup: ownPreDeployContext['securityGroups'][0].GroupId, //Only one created for this file system
-                    SubnetA: subnetA,
-                    SubnetB: subnetB
-                };
-                let efsTemplate = util.readFileSync(`${__dirname}/efs.yml`);
-
-                return cloudFormationCalls.createStack(stackName, efsTemplate, cloudFormationCalls.getCfStyleStackParameters(stackParameters))
-                    .then(createdStack => {
-                        let fileSystemId = getFileSystemIdFromStack(createdStack);
-                        return getDeployContext(ownServiceContext, fileSystemId, accountConfig['region'], stackName);
-                    });
+            if(!stack) { //Create
+                winston.info(`Creating S3 bucket ${stackName}`);
+                return cloudFormationCalls.createStack(stackName, s3Template, cloudFormationCalls.getCfStyleStackParameters(stackParams));
             }
             else {
-                winston.info(`Updates are not supported for the EFS service`);
-                let fileSystemId = getFileSystemIdFromStack(stack);
-                return getDeployContext(ownServiceContext, fileSystemId, accountConfig['region'], stackName);
+                winston.info(`Updating S3 bucket ${stackName}`);
+                return cloudFormationCalls.updateStack(stackName, s3Template, cloudFormationCalls.getCfStyleStackParameters(stackParams));
             }
+        })
+        .then(createdOrUpdatedStack => {
+            return getDeployContext(ownServiceContext, createdOrUpdatedStack);
         });
 }
 
@@ -196,7 +165,7 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
  * @returns {Promise.<ConsumeEventsContext>} - The information about the event consumption for this service
  */
 exports.consumeEvents = function(ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The EFS service doesn't consume events from other services"));
+    return Promise.reject(new Error("The S3 service doesn't consume events from other services"));
 }
 
 /**
@@ -218,7 +187,8 @@ exports.consumeEvents = function(ownServiceContext, ownDeployContext, produc
  * @returns {Promise.<ProduceEventsContext>} - The information about the event consumption for this service
  */
 exports.produceEvents = function(ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The EFS service doesn't produce events for other services"));
+    return Promise.reject(new Error("The S3 service doesn't currently produce events for other services"));
+//     return Promise.resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
 }
 
 /**
@@ -226,8 +196,7 @@ exports.produceEvents = function(ownServiceContext, ownDeployContext, consum
  * 
  * If the list is empty, this service cannot produce events to other services.
  */
-exports.producedEventsSupportedServices = [];
-
+exports.producedEventsSupportedServices = []; //TODO - No events supported yet, but we will support some like Lambda
 
 /**
  * The list of output types that this service produces. 
@@ -238,8 +207,7 @@ exports.producedEventsSupportedServices = [];
  */
 exports.producedDeployOutputTypes = [
     'environmentVariables',
-    'scripts',
-    'securityGroups'
+    'policies'
 ];
 
 /**

--- a/lib/services/s3/s3.yml
+++ b/lib/services/s3/s3.yml
@@ -1,0 +1,30 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Handel-created S3 bucket
+
+Parameters:
+  BucketName:
+    Description: The name of the bucket to create
+    Type: String
+  VersioningStatus:
+    Description: Whether to enable versioning or not
+    Type: String
+    AllowedValues:
+    - Enabled
+    - Suspended
+    Default: Suspended
+
+Resources:
+  Bucket:
+    Type: "AWS::S3::Bucket"
+    Properties: 
+      BucketName: 
+        Ref: BucketName
+      VersioningConfiguration:
+        Status: 
+          Ref: VersioningStatus
+Outputs:
+  BucketName:
+    Description: The name of the bucket
+    Value: 
+      Ref: Bucket

--- a/test/services/s3/s3-test.js
+++ b/test/services/s3/s3-test.js
@@ -1,0 +1,148 @@
+const accountConfig = require('../../../lib/util/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
+const s3 = require('../../../lib/services/s3');
+const cloudfFormationCalls = require('../../../lib/aws/cloudformation-calls');
+const ServiceContext = require('../../../lib/datatypes/service-context');
+const DeployContext = require('../../../lib/datatypes/deploy-context');
+const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
+const BindContext = require('../../../lib/datatypes/bind-context');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('efs deployer', function() {
+    let sandbox;
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('check', function() {
+        it('should require a bucket_name parameter', function() {
+            let serviceContext = {
+                params: {}
+            }
+            let errors = s3.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'bucket_name' parameter is required");
+        });
+
+        it('should require the versioning parameter to be a certain value when present', function() {
+            let serviceContext = {
+                params: {
+                    bucket_name: 'somename',
+                    versioning: 'othervalue'
+                }
+            }
+            let errors = s3.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'versioning' parameter must be either 'enabled' or 'disabled'");
+        });
+
+        it('should work when there are no configuration errors', function() {
+            let serviceContext = {
+                params: {
+                    bucket_name: 'somename',
+                    versioning: 'enabled'
+                }
+            }
+            let errors = s3.check(serviceContext);
+            expect(errors.length).to.equal(0);
+        });
+    });
+
+    describe('preDeploy', function() {
+        it('should return an empty predeploy context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return s3.preDeploy(serviceContext)
+                .then(preDeployContext => {
+                    expect(preDeployContext).to.be.instanceof(PreDeployContext);
+                });
+        });
+    });
+
+    describe('bind', function() {
+        it('should return an empty bind context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return s3.bind(serviceContext)
+                .then(bindContext => {
+                    expect(bindContext).to.be.instanceof(BindContext);
+                });
+        });
+    });
+
+    describe('deploy', function() {
+        let appName = "FakeApp";
+        let envName = "FakeEnv";
+        let deployVersion = "1";
+        let bucketName = "my-bucket";
+        let serviceContext = new ServiceContext(appName, envName, "FakeService", "s3", deployVersion, {
+            bucket_name: bucketName
+        });
+        let preDeployContext = new PreDeployContext(serviceContext);
+
+        it('should create a new bucket when it doesnt exist', function() {
+            let getStackStub = sandbox.stub(cloudfFormationCalls, 'getStack').returns(Promise.resolve(null));
+            let createStackStub = sandbox.stub(cloudfFormationCalls, 'createStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: 'BucketName',
+                    OutputValue: bucketName
+                }]
+            }))
+
+            return s3.deploy(serviceContext, preDeployContext, [])
+                .then(deployContext => {
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                    expect(deployContext.policies.length).to.equal(2);
+                    expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_BUCKET_NAME"]).to.equal(bucketName);
+                    expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_BUCKET_URL"]).to.contain(bucketName);
+                    expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_REGION_ENDPOINT"]).to.exist;
+                });
+        });
+
+        it('should update an existing bucket when it exists', function() {
+            let getStackStub = sandbox.stub(cloudfFormationCalls, 'getStack').returns(Promise.resolve({}));
+            let updateStackStub = sandbox.stub(cloudfFormationCalls, 'updateStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: 'BucketName',
+                    OutputValue: bucketName
+                }]
+            }))
+
+            return s3.deploy(serviceContext, preDeployContext, [])
+                .then(deployContext => {
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                    expect(deployContext.policies.length).to.equal(2);
+                    expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_BUCKET_NAME"]).to.equal(bucketName);
+                    expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_BUCKET_URL"]).to.contain(bucketName);
+                    expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_REGION_ENDPOINT"]).to.exist;
+                });
+        });
+    });
+
+    describe('consumeEvents', function() {
+        it('should return an error since it cant consume events', function() {
+            return s3.consumeEvents(null, null, null, null)
+                .then(() => {
+                    expect(true).to.be.false; //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("S3 service doesn't consume events");
+                });
+        });
+    });
+
+    describe('produceEvents', function() {
+        it('should return an error since it doesnt yet produce events', function() {
+            return s3.produceEvents(null, null, null, null)
+                .then(() => {
+                    expect(true).to.be.false; //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("S3 service doesn't currently produce events");
+                });
+        });
+    });
+});


### PR DESCRIPTION
This support is quite bare-bones, and only supports creating a
bucket with versioning. It does not yet support things like
lifecycle, logging, static websites, and notifications.

Resolves #11 