### PR TITLE
Fix bug where ECS creation fails on ALB target group

### DIFF
--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -56,20 +56,30 @@ function getClusterStackParameters(clusterName, taskDefinitionArn, serviceContex
         });
 }
 
-function createService(clusterName, taskDefinitionArn, serviceContext, preDeployContext, dependenciesDeployContexts) {
+function createService(stackName, taskDefinitionArn, serviceContext, preDeployContext, dependenciesDeployContexts) {
+    let clusterName = getShortenedClusterName(serviceContext);
     return getClusterStackParameters(clusterName, taskDefinitionArn, serviceContext, preDeployContext, dependenciesDeployContexts)
         .then(stackParameters => {
             let clusterTemplateBody = util.readFileSync(`${__dirname}/ecs-service.yml`);
-            return cloudformationCalls.createStack(clusterName, clusterTemplateBody, cloudformationCalls.getCfStyleStackParameters(stackParameters));
+            return cloudformationCalls.createStack(stackName, clusterTemplateBody, cloudformationCalls.getCfStyleStackParameters(stackParameters));
         });
 }
 
-function updateService(clusterName, taskDefinitionArn, serviceContext, preDeployContext, dependenciesDeployContexts) {
+function updateService(stackName, taskDefinitionArn, serviceContext, preDeployContext, dependenciesDeployContexts) {
+    let clusterName = getShortenedClusterName(serviceContext);
     return getClusterStackParameters(clusterName, taskDefinitionArn, serviceContext, preDeployContext, dependenciesDeployContexts)
         .then(stackParameters => {
             let clusterTemplateBody = util.readFileSync(`${__dirname}/ecs-service.yml`);
-            return cloudformationCalls.updateStack(clusterName, clusterTemplateBody, cloudformationCalls.getCfStyleStackParameters(stackParameters));
+            return cloudformationCalls.updateStack(stackName, clusterTemplateBody, cloudformationCalls.getCfStyleStackParameters(stackParameters));
         });
+}
+
+/**
+ * This function creates a short resource name for the cluster. We don't use the standard cf stack name here because the max length
+ *   of an ALB Target Group is 32 characters
+ */
+function getShortenedClusterName(serviceContext) {
+    return `${serviceContext.appName.substring(0, 21)}-${serviceContext.environmentName.substring(0, 4)}-${serviceContext.serviceName.substring(0, 9)}`;
 }
 
 
@@ -122,8 +132,8 @@ exports.bind = function(ownServiceContext, ownPreDeployContext, dependentOfServi
  * Deploy the instance of the service based on the service params passed in.
  */
 exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
-    let clusterName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`ECS - Deploying Cluster and Service ${clusterName}`);
+    let stackName = deployersCommon.getResourceName(ownServiceContext);
+    winston.info(`ECS - Deploying Cluster and Service ${stackName}`);
     let deployContext = new DeployContext(ownServiceContext);
 
     return deployersCommon.createCustomRoleForService("ecs-tasks.amazonaws.com", null, ownServiceContext, dependenciesDeployContexts)
@@ -132,21 +142,20 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
             return ecsCalls.registerTaskDefinition(taskDefinition)
         })
         .then(taskDefinition => {
-            return cloudformationCalls.getStack(clusterName)
+            return cloudformationCalls.getStack(stackName)
                 .then(serviceStack => {
                     if(!serviceStack) { //Create 
-                        winston.info(`Creating new ECS cluster ${clusterName}`);
-                        return createService(clusterName, taskDefinition.taskDefinitionArn, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts);
+                        winston.info(`Creating new ECS cluster ${stackName}`);
+                        return createService(stackName, taskDefinition.taskDefinitionArn, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts);
                     }
                     else { //Update
                         //TODO - If user data changed, then cycle all instances in a safe manner (https://github.com/colinbjohnson/aws-missing-tools/blob/master/aws-ha-release/aws-ha-release.sh)
-
-                        winston.info(`Updating existing ECS cluster ${clusterName}`);
-                        return updateService(clusterName, taskDefinition.taskDefinitionArn, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts);
+                        winston.info(`Updating existing ECS cluster ${stackName}`);
+                        return updateService(stackName, taskDefinition.taskDefinitionArn, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts);
                     }
                 })
                 .then(serviceStack => {
-                    winston.info(`ECS - Finished Deploying Cluster and Serivce ${clusterName}`);
+                    winston.info(`ECS - Finished Deploying Cluster and Serivce ${stackName}`);
                     return deployContext;
                 });
         });

--- a/test/services/ecs/ecs-test.js
+++ b/test/services/ecs/ecs-test.js
@@ -125,7 +125,7 @@ describe('ecs deployer', function() {
             let deployVersion = "1";
             
             //Set up ServiceContext
-            let ownServiceContext = getOwnServiceContextForDeploy();
+            let ownServiceContext = getOwnServiceContextForDeploy(appName, envName, deployVersion);
 
             //Set up PreDeployContext
             let ownPreDeployContext = getOwnPreDeployContextForDeploy(ownServiceContext);
@@ -164,7 +164,7 @@ describe('ecs deployer', function() {
             let deployVersion = "1";
             
             //Set up ServiceContext
-            let ownServiceContext = getOwnServiceContextForDeploy();
+            let ownServiceContext = getOwnServiceContextForDeploy(appName, envName, deployVersion);
 
             //Set up PreDeployContext
             let ownPreDeployContext = getOwnPreDeployContextForDeploy(ownServiceContext);


### PR DESCRIPTION
If the stack name is too long it fails, because the ALB target
group has a limit of 32 characters in the name.

This change makes the cluster name different from the stack name
so that we can support this limit.

Fixes #33.