### PR TITLE
Add initial Lambda functionality.

### DIFF
--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -1,0 +1,251 @@
+const winston = require('winston');
+const handlebarsUtils = require('../../util/handlebars-utils');
+const PreDeployContext = require('../../datatypes/pre-deploy-context');
+const BindContext = require('../../datatypes/bind-context');
+const DeployContext = require('../../datatypes/deploy-context');
+const accountConfig = require('../../util/account-config')().getAccountConfig();
+const cloudFormationCalls = require('../../aws/cloudformation-calls');
+const deployersCommon = require('../deployers-common');
+const uuid = require('uuid');
+
+
+function getEnvVariablesToInject(serviceContext, dependenciesDeployContexts) {
+    let serviceParams = serviceContext.params;
+    let envVarsToInject = deployersCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
+    if(serviceParams.environment_variables) {
+        for(let envVarName in serviceParams.environment_variables) {
+            envVarsToInject[envVarName] = serviceParams.environment_variables[envVarName];
+        }
+    }
+    return envVarsToInject;
+}
+
+
+function getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, customRole, s3ArtifactInfo) {
+    let serviceParams = ownServiceContext.params;
+    let memorySize = serviceParams.memory || 128;
+    let timeout = serviceParams.timeout || 3;
+    let handlebarsParams = {
+        functionName: stackName,
+        s3ArtifactBucket: s3ArtifactInfo.Bucket,
+        s3ArtifactKey: s3ArtifactInfo.Key,
+        executionRoleArn: customRole.Arn,
+        handler: serviceParams.handler,
+        runtime: serviceParams.runtime,
+        memorySize: memorySize,
+        timeout: timeout
+    };
+
+    //Inject environment variables (if any)
+    let envVarsToInject = getEnvVariablesToInject(ownServiceContext, dependenciesDeployContexts);
+    if(Object.keys(envVarsToInject).length > 0) {
+        handlebarsParams.environmentVariables = envVarsToInject;
+    }
+
+    return handlebarsUtils.compileTemplate(`${__dirname}/lambda-template.yml`, handlebarsParams)
+}
+
+function getDeployContext(serviceContext, cfStack) {
+    let deployContext = new DeployContext(serviceContext);
+    return deployContext;
+}
+
+function uploadDeployableArtifactToS3(serviceContext) {
+    let s3FileName = `lambda-deployable-${uuid()}.zip`;
+    winston.info(`Uploading deployable artifact to S3: ${s3FileName}`);
+    return deployersCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
+        .then(s3ArtifactInfo => {
+            winston.info(`Uploaded deployable artifact to S3: ${s3FileName}`);
+            return s3ArtifactInfo;
+        });
+}
+
+function getPolicyStatementsForLambdaRole() {
+    return [
+        {
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "arn:aws:logs:*:*:*",
+            "Effect": "Allow"
+        }
+    ]
+}
+
+
+/**
+ * Checks the given service for required parameters and correctness. This provides
+ * a fail-fast mechanism for configuration errors before deploy is attempted.
+ *
+ * @param {ServiceContext} serviceContext - The ServiceContext for the service to check
+ * @returns {Array} - 0 or more String error messages
+ */
+exports.check = function (serviceContext) {
+    let errors = [];
+    
+    let serviceParams = serviceContext.params;
+    if(!serviceParams.path_to_code) {
+        errors.push("Lambda - The 'path_to_code' parameter is required");
+    }
+    if(!serviceParams.handler) {
+        errors.push("Lambda - The 'handler' parameter is required");
+    }
+    if(!serviceParams.runtime) {
+        errors.push("Lambda - The 'runtime' parameter is required");
+    }
+
+    return errors;
+}
+
+
+/**
+ * Create resources needed for deployment that are also needed for dependency wiring
+ * with other services
+ *
+ * @param {ServiceContext} serviceContext - The ServiceContext for the service to check
+ * @returns {Promise.<PreDeployContext>} - A Promise of the PreDeployContext results from the pre-deploy
+ */
+exports.preDeploy = function (serviceContext) {
+    winston.info(`Lambda - PreDeploy is not required for this service, skipping it`);
+    return Promise.resolve(new PreDeployContext(serviceContext));
+}
+
+
+/**
+ * Bind two resources from PreDeploy together by performing some wiring action on them. An example * is to add an ingress rule from one security group onto another. Wiring actions may also be
+ * performed in the Deploy phase if there isn't a two-way linkage. For example, security groups
+ * probably need to be done in PreDeploy and Bind, but environment variables from one service to
+ * another can just be done in Deploy
+ *
+ * Bind is run from the perspective of the service being consumed, not the other way around.
+ *
+ * Do not use this phase for creating resources. Those should be done either in PreDeploy or Deploy.
+ * This phase is for wiring up existing resources from PreDeploy
+ *
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being consumed
+ * @param {PreDeployContext} ownPreDeployContext - The PreDeployContext of the service being consumed
+ * @param {ServiceContext} dependentOfServiceContext - The ServiceContext of the service consuming this one
+ * @param {PreDeployContext} dependentOfPreDeployContext - The PreDeployContext of the service consuming this one
+ * @returns {Promise.<BindContext>} - A Promise of the BindContext results from the Bind
+ */
+exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
+    winston.info(`Lambda - Bind is not required for this service, skipping it`);
+    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+}
+
+
+/**
+ * Deploy the given resource, wiring it up with results from the DeployContexts of services
+ * that this one depends on. All dependencies are guaranteed to be deployed before the ones
+ * consuming them
+ *
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deployed
+ * @param {PreDeployContext} ownPreDeployContext - The PreDeployContext of the service being deployed
+ * @param {Array<DeployContext>} dependenciesDeployContexts - The DeployContexts of the services that this one depends on
+ * @returns {Promise.<DeployContext>} - A Promise of the DeployContext from this deploy
+ */
+exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
+    let stackName = deployersCommon.getResourceName(ownServiceContext);
+    winston.info(`Lambda - Executing Deploy on ${stackName}`);
+
+    return deployersCommon.createCustomRoleForService('lambda.amazonaws.com', getPolicyStatementsForLambdaRole(), ownServiceContext, dependenciesDeployContexts)
+        .then(customRole => {
+            return uploadDeployableArtifactToS3(ownServiceContext)
+                .then(s3ArtifactInfo => {
+                    return getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, customRole, s3ArtifactInfo);
+                });
+        })
+        .then(compiledLambdaTemplate => {
+            return cloudFormationCalls.getStack(stackName)
+                .then(stack => {
+                    if (!stack) {
+                        winston.info(`Lambda - Creating Lambda function ${stackName}`);
+                        return cloudFormationCalls.createStack(stackName, compiledLambdaTemplate, []);
+                    }
+                    else {
+                        winston.info(`Lambda - Updating Lambda function ${stackName}`);
+                        return cloudFormationCalls.updateStack(stackName, compiledLambdaTemplate, []);
+                    }
+                })
+        })
+        .then(deployedStack => {
+            winston.info(`Lambda - Finished deploying Lambda function ${stackName}`);
+            return getDeployContext(ownServiceContext, deployedStack);
+        });
+}
+
+/**
+ * In this phase, this service should make any changes necessary to allow it to consume events from the given source
+ * For example, a Lambda consuming events from an SNS topic should add a Lambda Function Permission to itself to allow
+ * the SNS ARN to invoke it.
+ * 
+ * Some events like DynamoDB -> Lambda will do all the work in here because Lambda uses a polling model to 
+ *   DynamoDB, so the DynamoDB service doesn't need to do any configuration itself. Most services will only do half
+ *   the work here, however, to grant permissions to the producing service. 
+ * 
+ * This method will only be called if your service is listed as an event consumer in another service's configuration.
+ * 
+ * Throw an exception in this method if your service doesn't consume any events at all.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service consuming events
+ * @param {DeployContext} ownDeployContext - The DeployContext of this service consuming events
+ * @param {ServiceContext} producerServiceContext - The ServiceContext of the service that will be producing events for this service
+ * @param {DeployContext} producerDeployContext - The DeployContext of the service that will be producing events for this service.
+ * @returns {Promise.<ConsumeEventsContext>} - The information about the event consumption for this service
+ */
+exports.consumeEvents  =  function (ownServiceContext,  ownDeployContext,  producerServiceContext,  producerDeployContext)  {
+    return Promise.reject(new Error("The Lambda service doesn't consume events from other services"));
+}
+
+/**
+ * In this phase, this service should make any changes necessary to allow it to produce events to the consumer service.
+ * For example, an S3 bucket producing events to a Lambda should add the event notifications to the S3 bucket for the
+ * Lambda.
+ * 
+ * Some events, like DynamoDB -> Lambda, won't do any work here to produce events, because Lambda uses a polling
+ *   model. In cases like these, you can just return 
+ * 
+ * This method will only be called if your service has an event_consumers element in its configruation.
+ * 
+ * Throw an exception in this method if your service doesn't produce any events to any sources.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service producing events
+ * @param {DeployContext} ownDeployContext - The DeployContext of this service producing events
+ * @param {ServiceContext} producerServiceContext - The ServiceContext of the service that will be consuming events for this service
+ * @param {DeployContext} producerDeployContext - The DeployContext of the service that will be consuming events for this service.
+ * @returns {Promise.<ProduceEventsContext>} - The information about the event consumption for this service
+ */
+exports.produceEvents  =  function (ownServiceContext,  ownDeployContext,  consumerServiceContext,  consumerDeployContext)  {
+    return Promise.reject(new Error("The Lambda service doesn't produce events for other services"));
+}
+
+/**
+ * List of event sources this service can integrate with.
+ * 
+ * If the list is empty, this service cannot produce events to other services.
+ */
+exports.producedEventsSupportedServices  =  [];
+
+
+/**
+ * The list of output types that this service produces. 
+ * 
+ * If the list is empty, this service cannot be consumed by other resources.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.producedDeployOutputTypes = [];
+
+/**
+ * The list of output types that this service consumes from other dependencies.
+ * 
+ * If the list is empty, this service cannot consume other services.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.consumedDeployOutputTypes = [
+    'environmentVariables',
+    'policies'
+];

--- a/lib/services/lambda/lambda-template.yml
+++ b/lib/services/lambda/lambda-template.yml
@@ -1,0 +1,36 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Handel-created Lambda function
+
+Resources:
+  Function:
+    Type: AWS::Lambda::Function
+    Properties: 
+      Code:
+        S3Bucket: {{s3ArtifactBucket}}
+        S3Key: {{s3ArtifactKey}}
+      Description: Handel-created function {{functionName}}
+      {{#if environmentVariables}}
+      Environment:
+        Variables:
+          {{#each environmentVariables}}
+          {{@key}}: {{this}}
+          {{/each}}
+      {{/if}}
+      FunctionName: {{functionName}}
+      Handler: {{handler}}
+      MemorySize: {{memorySize}}
+      Role: {{executionRoleArn}}
+      Runtime: {{runtime}}
+      Timeout: {{timeout}}
+      # No VPC support for now
+Outputs:
+  FunctionName:
+    Description: The name of the function
+    Value: !Ref Function
+  FunctionArn:
+    Description: The ARN of the function
+    Value: 
+      Fn::GetAtt: 
+        - "Function"
+        - "Arn"

--- a/test/services/lambda/lambda-test.js
+++ b/test/services/lambda/lambda-test.js
@@ -1,0 +1,193 @@
+const accountConfig = require('../../../lib/util/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
+const lambda = require('../../../lib/services/lambda');
+const cloudFormationCalls = require('../../../lib/aws/cloudformation-calls');
+const ServiceContext = require('../../../lib/datatypes/service-context');
+const DeployContext = require('../../../lib/datatypes/deploy-context');
+const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
+const BindContext = require('../../../lib/datatypes/bind-context');
+const deployersCommon = require('../../../lib/services/deployers-common');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('lambda deployer', function() {
+    let sandbox;
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('check', function() {
+        it('should require the path_to_code parameter', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {
+                handler: 'index.handler',
+                runtime: 'nodejs6.11'
+            });
+            let errors = lambda.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'path_to_code' parameter is required");
+        });
+
+        it('should require the handler parameter', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {
+                path_to_code: '.',
+                runtime: 'nodejs6.11'
+            });
+            let errors = lambda.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'handler' parameter is required");
+        });
+
+        it('should require the runtime parameter', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {
+                path_to_code: '.',
+                handler: 'index.handler'
+            });
+            let errors = lambda.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'runtime' parameter is required");
+        });
+
+        it('should work when things are configured properly', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {
+                path_to_code: '.',
+                runtime: 'nodejs6.11',
+                handler: 'index.handler'
+            });
+            let errors = lambda.check(serviceContext);
+            expect(errors.length).to.equal(0);
+        });
+    });
+
+    describe('preDeploy', function() {
+        it('should return an empty predeploy context since it doesnt do anything', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return lambda.preDeploy(serviceContext)
+                .then(preDeployContext => {
+                    expect(preDeployContext).to.be.instanceof(PreDeployContext);
+                    expect(preDeployContext.appName).to.equal(serviceContext.appName);
+                });
+        });
+    });
+
+    describe('bind', function() {
+        it('should return an empty bind context since it doesnt do anything', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return lambda.bind(serviceContext)
+                .then(bindContext => {
+                    expect(bindContext).to.be.instanceof(BindContext);
+                    expect(bindContext.dependencyServiceContext.appName).to.equal(serviceContext.appName);
+                });
+        });
+    });
+
+    describe('deploy', function() {
+        function getServiceContext() {
+            return new ServiceContext("FakeApp", "FakeEnv", "FakeService", "lambda", "1", {
+                memory: 256,
+                timeout: 5,
+                path_to_code: ".",
+                handler: 'index.handler',
+                runtime: 'nodejs6.11',
+                environment_variables: {
+                    MY_FIRST_VAR: 'my_first_value'
+                }
+            });
+        }
+
+        function getPreDeployContext(serviceContext) {
+            return new PreDeployContext(serviceContext);
+        }
+
+        function getDependenciesDeployContexts() {
+            let dependenciesDeployContexts = [];
+
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService2", "dynamodb", "1", {
+                
+            });
+            let deployContext = new DeployContext(serviceContext);
+            deployContext.environmentVariables['INJECTED_VAR'] = 'injectedValue';
+            deployContext.policies.push({});
+
+            return dependenciesDeployContexts;
+        }
+
+        
+        it('should create the service when it doesnt already exist', function() {
+            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
+                Arn: "FakeArn"
+            }));
+            let uploadArtifactStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
+                Key: "FakeKey",
+                Bucket: "FakeBucket"
+            }));
+            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve(null));
+            let createStackStub = sandbox.stub(cloudFormationCalls, 'createStack').returns(Promise.resolve({}));
+
+            let ownServiceContext = getServiceContext();
+            let ownPreDeployContext = getPreDeployContext(ownServiceContext);
+            let dependenciesDeployContexts = getDependenciesDeployContexts();
+
+            return lambda.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
+                .then(deployContext => {
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                    expect(createCustomRoleStub.calledOnce).to.be.true;
+                    expect(uploadArtifactStub.calledOnce).to.be.true;
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(createStackStub.calledOnce).to.be.true;
+                });
+        });
+
+        it('should update the service when it already exists', function() {
+            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
+                Arn: "FakeArn"
+            }));
+            let uploadArtifactStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
+                Key: "FakeKey",
+                Bucket: "FakeBucket"
+            }));
+            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({}));
+            let updateStackStub = sandbox.stub(cloudFormationCalls, 'updateStack').returns(Promise.resolve({}));
+
+            let ownServiceContext = getServiceContext();
+            let ownPreDeployContext = getPreDeployContext(ownServiceContext);
+            let dependenciesDeployContexts = getDependenciesDeployContexts();
+
+            return lambda.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
+                .then(deployContext => {
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                    expect(createCustomRoleStub.calledOnce).to.be.true;
+                    expect(uploadArtifactStub.calledOnce).to.be.true;
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(updateStackStub.calledOnce).to.be.true;
+                });
+        });
+    });
+
+    describe('consumerEvents', function() {
+        it('should throw an error because EFS doesnt consume event services', function() {
+            return lambda.consumeEvents(null, null, null, null)
+                .then(consumeEventsContext => {
+                    expect(true).to.be.false; //Shouldnt get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("Lambda service doesn't consume events");
+                });
+        });
+    });
+
+    describe('produceEvents', function() {
+        it('should throw an error because EFS doesnt produce events for other services', function() {
+            return lambda.produceEvents(null, null, null, null)
+                .then(produceEventsContext => {
+                    expect(true).to.be.false; //Shouldnt get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("Lambda service doesn't produce events");
+                });
+        });
+    });
+});


### PR DESCRIPTION
This change adds the initial functionality for the Lambda service.
This service by itself isn't terribly useful unless people are
invoking it. There will be changes made to services like SNS and
Lambda to support events coming from SNS to Lambda.

Resolves #28 