### PR TITLE
Add suport for SSM parameter store in compute services

### DIFF
--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -39,7 +39,7 @@ function uploadDeployableArtifactToS3(serviceContext) {
         });
 }
 
-function getPolicyStatementsForLambdaRole() {
+function getPolicyStatementsForLambdaRole(serviceContext) {
     return [{
         "Effect": "Allow",
         "Action": [
@@ -48,7 +48,7 @@ function getPolicyStatementsForLambdaRole() {
             "logs:PutLogEvents"
         ],
         "Resource": "*"
-    }]
+    }].concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
 }
 
 function getEnvVarsForService(serviceContext, dependenciesDeployContexts) {
@@ -183,7 +183,7 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
 
     return uploadDeployableArtifactToS3(ownServiceContext)
         .then(s3ObjectInfo => {
-            return deployersCommon.createCustomRoleForService("lambda.amazonaws.com", getPolicyStatementsForLambdaRole(), ownServiceContext, dependenciesDeployContexts)
+            return deployersCommon.createCustomRoleForService("lambda.amazonaws.com", getPolicyStatementsForLambdaRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
                 .then(role => {
                     return getStackParameters(stackName, s3ObjectInfo.Bucket, s3ObjectInfo.Key, ownServiceContext, role);
                 });

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -86,7 +86,7 @@ function getDeployContext(serviceContext, cfStack) {
  * This returns the policy needed for Beanstalk to work in the web
  * tier, including Docker ECS multi-container support
  */
-function getPolicyStatementForBeanstalkRole() {
+function getPolicyStatementForBeanstalkRole(serviceContext) {
     return [
         {
             "Sid": "BucketAccess",
@@ -138,7 +138,7 @@ function getPolicyStatementForBeanstalkRole() {
             ],
             "Resource": "*"
         }
-    ];
+    ].concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
 }
 
 function uploadDeployableArtifactToS3(serviceContext) {
@@ -274,7 +274,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`Beanstalk - Executing Deploy on ${stackName}`);
 
-    return deployersCommon.createCustomRoleForService('ec2.amazonaws.com', getPolicyStatementForBeanstalkRole(), ownServiceContext, dependenciesDeployContexts)
+    return deployersCommon.createCustomRoleForService('ec2.amazonaws.com', getPolicyStatementForBeanstalkRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
         .then(customRole => {
             return uploadDeployableArtifactToS3(ownServiceContext)
                 .then(s3ArtifactInfo => {

--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -14,11 +14,11 @@ const util = require('../util/util');
  * @param {String} suffix - The remaining part of the environment variable
  * @returns {String} - The environment variable prefix string constructed from the service context
  */
-exports.getInjectedEnvVarName = function(serviceContext, suffix) {
+exports.getInjectedEnvVarName = function (serviceContext, suffix) {
     return `${serviceContext.serviceType}_${serviceContext.appName}_${serviceContext.environmentName}_${serviceContext.serviceName}_${suffix}`.toUpperCase().replace(/-/g, "_");
 }
 
-exports.getEnvVarsFromServiceContext = function(serviceContext) {
+exports.getEnvVarsFromServiceContext = function (serviceContext) {
     let envVars = {};
     envVars['HANDEL_APP_NAME'] = serviceContext.appName;
     envVars['HANDEL_ENVIRONMENT_NAME'] = serviceContext.environmentName;
@@ -27,35 +27,35 @@ exports.getEnvVarsFromServiceContext = function(serviceContext) {
     return envVars;
 }
 
-exports.getEnvVarsFromDependencyDeployContexts = function(deployContexts) {
+exports.getEnvVarsFromDependencyDeployContexts = function (deployContexts) {
     let envVars = {};
-    for(let deployContext of deployContexts) {
-        for(let envVarKey in deployContext.environmentVariables) {
+    for (let deployContext of deployContexts) {
+        for (let envVarKey in deployContext.environmentVariables) {
             envVars[envVarKey] = deployContext.environmentVariables[envVarKey];
         }
     }
     return envVars;
 }
 
-exports.createCustomRoleForService = function(trustedService, ownServicePolicyStatements, ownServiceContext, dependenciesDeployContexts) {
+exports.createCustomRoleForService = function (trustedService, ownServicePolicyStatements, ownServiceContext, dependenciesDeployContexts) {
     let policyStatementsToConsume = [];
 
     //Add policies from dependencies that have them
-    for(let deployContext of dependenciesDeployContexts) {
-        for(let policyDoc of deployContext.policies) {
+    for (let deployContext of dependenciesDeployContexts) {
+        for (let policyDoc of deployContext.policies) {
             policyStatementsToConsume.push(policyDoc);
         }
     }
 
     //Let consuming service add its own policy if needed
-    for(let ownServicePolicyStatement of ownServicePolicyStatements) {
+    for (let ownServicePolicyStatement of ownServicePolicyStatements) {
         policyStatementsToConsume.push(ownServicePolicyStatement);
     }
 
     let roleName = `${ownServiceContext.appName}-${ownServiceContext.environmentName}-${ownServiceContext.serviceName}-${ownServiceContext.serviceType}`;
     return iamCalls.createRoleIfNotExists(roleName, trustedService)
         .then(role => {
-            if(policyStatementsToConsume.length > 0) { //Only add policies if there are any to consume
+            if (policyStatementsToConsume.length > 0) { //Only add policies if there are any to consume
                 let policyArn = `arn:aws:iam::${accountConfig.account_id}:policy/services/${roleName}`;
                 let policyDocument = iamCalls.constructPolicyDoc(policyStatementsToConsume);
                 return iamCalls.createOrUpdatePolicy(roleName, policyArn, policyDocument)
@@ -72,14 +72,14 @@ exports.createCustomRoleForService = function(trustedService, ownServicePolicySt
         });
 }
 
-exports.createSecurityGroupForService = function(sgName, addSshIngress) {
+exports.createSecurityGroupForService = function (sgName, addSshIngress) {
     return ec2Calls.createSecurityGroupIfNotExists(sgName, accountConfig['vpc'])
         .then(securityGroup => {
             //Add ingress from self
             return ec2Calls.addIngressRuleToSgIfNotExists(securityGroup, securityGroup, 'tcp', 0, 65535, accountConfig['vpc']);
         })
         .then(securityGroup => {
-            if(addSshIngress) {
+            if (addSshIngress) {
                 //Add ingress from SSH bastion
                 return ec2Calls.getSecurityGroupById(accountConfig.ssh_bastion_sg, accountConfig.vpc)
                     .then(sshBastionSg => {
@@ -92,15 +92,15 @@ exports.createSecurityGroupForService = function(sgName, addSshIngress) {
         });
 }
 
-exports.checkRoutingElement = function(serviceContext) {
+exports.checkRoutingElement = function (serviceContext) {
     let errors = [];
     let serviceParams = serviceContext.params;
-    if(serviceParams.routing) {
-        if(!serviceParams.routing.type) {
+    if (serviceParams.routing) {
+        if (!serviceParams.routing.type) {
             errors.push(`${serviceContext.serviceType} - The 'type' field is required in the 'routing' section`);
         }
         else {
-            if(serviceParams.routing.type === 'https' && !serviceParams.routing.https_certificate) {
+            if (serviceParams.routing.type === 'https' && !serviceParams.routing.https_certificate) {
                 errors.push(`${serviceContext.serviceType} - The 'https_certificate' element is required when you are using 'https' as the routing type`);
             }
         }
@@ -108,21 +108,21 @@ exports.checkRoutingElement = function(serviceContext) {
     return errors;
 }
 
-exports.getRoutingInformationForService = function(serviceContext) {
+exports.getRoutingInformationForService = function (serviceContext) {
     let serviceParams = serviceContext.params;
-    if(serviceParams.routing) {
+    if (serviceParams.routing) {
         let routingInfo = {
             type: serviceParams.routing.type,
             timeout: 60,
             healthCheckPath: '/'
         };
-        if(serviceParams.routing.timeout) {
+        if (serviceParams.routing.timeout) {
             routingInfo.timeout = serviceParams.routing.timeout;
         }
-        if(serviceParams.routing.health_check_path) {
+        if (serviceParams.routing.health_check_path) {
             routingInfo.healthCheckPath = serviceParams.routing.health_check_path;
         }
-        if(routingInfo.type === 'https') {
+        if (routingInfo.type === 'https') {
             routingInfo.httpsCertificate = `arn:aws:acm:us-west-2:${accountConfig.account_id}:certificate/${serviceParams.routing.https_certificate}`;
         }
         return routingInfo;
@@ -130,9 +130,9 @@ exports.getRoutingInformationForService = function(serviceContext) {
     return null; //No routing specified
 }
 
-exports.uploadFileToHandelBucket = function(serviceContext, diskFilePath, s3FileName) {
+exports.uploadFileToHandelBucket = function (serviceContext, diskFilePath, s3FileName) {
     let bucketName = `handel-${accountConfig.region}-${accountConfig.account_id}`;
-    
+
     return s3Calls.createBucketIfNotExists(bucketName, accountConfig.region) //Ensure Handel bucket exists in this region
         .then(bucket => {
             let artifactKey = `${serviceContext.appName}/${serviceContext.environmentName}/${serviceContext.serviceName}/${s3FileName}`;
@@ -140,10 +140,10 @@ exports.uploadFileToHandelBucket = function(serviceContext, diskFilePath, s3File
         });
 }
 
-exports.uploadDeployableArtifactToHandelBucket = function(serviceContext, s3FileName) {
+exports.uploadDeployableArtifactToHandelBucket = function (serviceContext, s3FileName) {
     let pathToArtifact = serviceContext.params.path_to_code;
     let fileStats = fs.lstatSync(pathToArtifact);
-    if(fileStats.isDirectory()) { //Zip up artifact
+    if (fileStats.isDirectory()) { //Zip up artifact
         let zippedPath = `/tmp/${s3FileName}.zip`;
         return util.zipDirectoryToFile(pathToArtifact, zippedPath)
             .then(() => {
@@ -163,7 +163,26 @@ exports.uploadDeployableArtifactToHandelBucket = function(serviceContext, s3File
     }
 }
 
+exports.getAppSecretsAccessPolicyStatements = function (serviceContext) {
+    return  [
+        {
+            Effect: "Allow",
+            Action: [
+                "ssm:DescribeParameters"
+            ],
+            Resource: "*"
+        },
+        {
+            Effect: "Allow",
+            Action: [
+                "ssm:GetParameters"
+            ],
+            Resource: `arn:aws:ssm:${accountConfig.region}:${accountConfig.account_id}:parameter/${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}*`
+        }
+    ]
+}
 
-exports.getResourceName = function(serviceContext) {
+
+exports.getResourceName = function (serviceContext) {
     return `${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}-${serviceContext.serviceType}`;
 }

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -140,7 +140,7 @@ function createEcsServiceRoleIfNotExists() {
 function getClusterStackParameters(clusterName, serviceContext, preDeployContext, dependenciesDeployContexts) {
     return getUserDataScript(clusterName, dependenciesDeployContexts)
         .then(userDataScript => {
-            return deployersCommon.createCustomRoleForService("ecs-tasks.amazonaws.com", [], serviceContext, dependenciesDeployContexts)
+            return deployersCommon.createCustomRoleForService("ecs-tasks.amazonaws.com", deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext), serviceContext, dependenciesDeployContexts)
                 .then(taskRole => {
                     return createEcsServiceRoleIfNotExists()
                         .then(ecsServiceRole => {

--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -64,7 +64,7 @@ function uploadDeployableArtifactToS3(serviceContext) {
         });
 }
 
-function getPolicyStatementsForLambdaRole() {
+function getPolicyStatementsForLambdaRole(serviceContext) {
     return [
         {
             "Action": [
@@ -75,7 +75,7 @@ function getPolicyStatementsForLambdaRole() {
             "Resource": "arn:aws:logs:*:*:*",
             "Effect": "Allow"
         }
-    ]
+    ].concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
 }
 
 
@@ -189,7 +189,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`Lambda - Executing Deploy on ${stackName}`);
 
-    return deployersCommon.createCustomRoleForService('lambda.amazonaws.com', getPolicyStatementsForLambdaRole(), ownServiceContext, dependenciesDeployContexts)
+    return deployersCommon.createCustomRoleForService('lambda.amazonaws.com', getPolicyStatementsForLambdaRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
         .then(customRole => {
             return uploadDeployableArtifactToS3(ownServiceContext)
                 .then(s3ArtifactInfo => {

--- a/test/services/deployers-common-test.js
+++ b/test/services/deployers-common-test.js
@@ -298,4 +298,16 @@ describe('deployers-common', function() {
                 });
         });
     });
+
+    describe('getAppSecretsAccessPolicyStatements', function() {
+        it('should return an array of two permissions allowing it to access secrets in its namespace', function() {
+            let appName = "FakeApp";
+            let envName = "FakeEnv";
+            let serviceName = "FakeService";
+            let serviceContext = new ServiceContext(appName, envName, serviceName, "lambda", "1", {});
+            let policyStatements = deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext);
+            expect(policyStatements.length).to.equal(2);
+            expect(policyStatements[1].Resource).to.contain(`parameter/${appName}-${envName}-${serviceName}*`)
+        });
+    });
 });


### PR DESCRIPTION
This is just an initial piece of functionality to allow apps to talk to parameter store for their secrets, isolated to just their application namespace specified by the prefix <appname>-<envname>-<servicename>

Resolves #61 