### PR TITLE
Add initial CloudWatch Events support

### DIFF
--- a/lib/aws/cloudwatch-events-calls.js
+++ b/lib/aws/cloudwatch-events-calls.js
@@ -1,0 +1,33 @@
+const AWS = require('aws-sdk');
+const winston = require('winston');
+
+/**
+ * This function doesn't support the following target types yet:
+ * * ECS
+ * * Kinesis
+ * * EC2 Run Command
+ * 
+ * It also doesn't support the InputPath or InputTransformer yet
+ */
+exports.addTarget = function (ruleName, targetArn, targetId, input) {
+    const cloudWatchEvents = new AWS.CloudWatchEvents({ apiVersion: '2015-10-07' });
+
+    let putParams = {
+        Rule: ruleName,
+        Targets: [
+            {
+                Arn: targetArn,
+                Id: targetId
+            }
+        ]
+    };
+    if(input) { //Not all targets will want to override input, but some like scheduled Lambda will.
+        putParams.Targets[0].Input = input;
+    }
+    winston.debug(`Adding target '${targetArn}' to rule '${ruleName}'`)
+    return cloudWatchEvents.putTargets(putParams).promise()
+        .then(putResponse => {
+            winston.debug(`Added target '${targetArn}' to rule '${ruleName}'`);
+            return targetId;
+        });
+}

--- a/lib/services/cloudwatchevent/event-rule-template.yml
+++ b/lib/services/cloudwatchevent/event-rule-template.yml
@@ -1,0 +1,27 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Handel-created CloudWatch Events Rule
+
+Resources:
+  EventsRule:
+    Type: "AWS::Events::Rule"
+    Properties: 
+      Description: Handel-created rule for {{ruleName}}
+      {{#if scheduleExpression}}
+      ScheduleExpression: {{scheduleExpression}}
+      {{/if}}
+      Name: {{ruleName}}
+      State: {{state}}
+      # Targets are defined dynamically by event_consumers in the produceEvents phase
+
+Outputs:
+  EventRuleId:
+    Description: The ID of the event rule
+    Value: 
+      Ref: EventsRule
+  EventRuleArn:
+    Description: The ARN of the event rule
+    Value:
+      Fn::GetAtt: 
+        - EventsRule
+        - Arn

--- a/lib/services/cloudwatchevent/index.js
+++ b/lib/services/cloudwatchevent/index.js
@@ -1,83 +1,49 @@
 const winston = require('winston');
-const handlebarsUtils = require('../../util/handlebars-utils');
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
-const ConsumeEventsContext = require('../../datatypes/consume-events-context');
+const ProduceEventsContext = require('../../datatypes/produce-events-context');
 const accountConfig = require('../../util/account-config')().getAccountConfig();
+const cloudWatchEventsCalls = require('../../aws/cloudwatch-events-calls');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
-const lambdaCalls = require('../../aws/lambda-calls');
 const deployersCommon = require('../deployers-common');
-const uuid = require('uuid');
+const util = require('../../util/util');
+const handlebarsUtils = require('../../util/handlebars-utils');
+const yaml = require('js-yaml');
 
-
-function getEnvVariablesToInject(serviceContext, dependenciesDeployContexts) {
-    let serviceParams = serviceContext.params;
-    let envVarsToInject = deployersCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
-    if (serviceParams.environment_variables) {
-        for (let envVarName in serviceParams.environment_variables) {
-            envVarsToInject[envVarName] = serviceParams.environment_variables[envVarName];
-        }
-    }
-    return envVarsToInject;
-}
-
-
-function getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, customRole, s3ArtifactInfo) {
-    let serviceParams = ownServiceContext.params;
-    let memorySize = serviceParams.memory || 128;
-    let timeout = serviceParams.timeout || 3;
-    let handlebarsParams = {
-        functionName: stackName,
-        s3ArtifactBucket: s3ArtifactInfo.Bucket,
-        s3ArtifactKey: s3ArtifactInfo.Key,
-        executionRoleArn: customRole.Arn,
-        handler: serviceParams.handler,
-        runtime: serviceParams.runtime,
-        memorySize: memorySize,
-        timeout: timeout
-    };
-
-    //Inject environment variables (if any)
-    let envVarsToInject = getEnvVariablesToInject(ownServiceContext, dependenciesDeployContexts);
-    if (Object.keys(envVarsToInject).length > 0) {
-        handlebarsParams.environmentVariables = envVarsToInject;
-    }
-
-    return handlebarsUtils.compileTemplate(`${__dirname}/lambda-template.yml`, handlebarsParams)
-}
-
-function getDeployContext(serviceContext, cfStack) {
+function getDeployContext(serviceContext, deployedStack) {
     let deployContext = new DeployContext(serviceContext);
-    deployContext.eventOutputs.lambdaArn = cloudFormationCalls.getOutput('FunctionArn', cfStack);
-    deployContext.eventOutputs.lambdaName = cloudFormationCalls.getOutput('FunctionName', cfStack);
+
+    //Event outputs for consumers of CloudWatch events
+    let eventRuleArn = cloudFormationCalls.getOutput('EventRuleArn', deployedStack);
+    deployContext.eventOutputs.eventRuleArn = eventRuleArn;
+    deployContext.eventOutputs.principal = "events.amazonaws.com";
+
     return deployContext;
 }
 
-function uploadDeployableArtifactToS3(serviceContext) {
-    let s3FileName = `lambda-deployable-${uuid()}.zip`;
-    winston.info(`Lambda - Uploading deployable artifact to S3: ${s3FileName}`);
-    return deployersCommon.uploadDeployableArtifactToHandelBucket(serviceContext, s3FileName)
-        .then(s3ArtifactInfo => {
-            winston.info(`Lambda - Uploaded deployable artifact to S3: ${s3FileName}`);
-            return s3ArtifactInfo;
+function getCompiledEventRuleTemplate(stackName, serviceContext) {
+    let serviceParams = serviceContext.params;
+    let state = serviceParams.state || 'enabled';
+    let handlebarsParams = {
+        ruleName: stackName,
+        state: state.toUpperCase()
+    }
+    if (serviceParams.schedule) {
+        handlebarsParams.scheduleExpression = serviceParams.schedule;
+    }
+    return handlebarsUtils.compileTemplate(`${__dirname}/event-rule-template.yml`, handlebarsParams)
+        .then(template => {
+            //NOTE: This is a bit odd, but the syntax of event patterns is complex enough that it's easiest to just provide
+            //  a pass-through to the AWS event rule syntax for anyone wanting to specify an event pattern.
+            let templateObj = yaml.safeLoad(template);
+            if(serviceParams.event_pattern) {
+                templateObj.Resources.EventsRule.Properties.EventPattern = serviceParams.event_pattern;
+            }
+            let templateStr = yaml.safeDump(templateObj);
+            return templateStr;
         });
 }
-
-function getPolicyStatementsForLambdaRole(serviceContext) {
-    return [
-        {
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents"
-            ],
-            "Resource": "arn:aws:logs:*:*:*",
-            "Effect": "Allow"
-        }
-    ].concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
-}
-
 
 /**
  * Checks the given service for required parameters and correctness. This provides
@@ -90,14 +56,10 @@ exports.check = function (serviceContext) {
     let errors = [];
 
     let serviceParams = serviceContext.params;
-    if (!serviceParams.path_to_code) {
-        errors.push("Lambda - The 'path_to_code' parameter is required");
-    }
-    if (!serviceParams.handler) {
-        errors.push("Lambda - The 'handler' parameter is required");
-    }
-    if (!serviceParams.runtime) {
-        errors.push("Lambda - The 'runtime' parameter is required");
+
+    //Require 'schedule' or 'event_pattern'
+    if(!serviceParams.schedule && !serviceParams.event_pattern) {
+        errors.push(`CloudWatch Events - You must specify at least one of the 'schedule' or 'event_pattern' parameters`);
     }
 
     return errors;
@@ -112,7 +74,7 @@ exports.check = function (serviceContext) {
  * @returns {Promise.<PreDeployContext>} - A Promise of the PreDeployContext results from the pre-deploy
  */
 exports.preDeploy = function (serviceContext) {
-    winston.info(`Lambda - PreDeploy is not required for this service, skipping it`);
+    winston.info(`CloudWatch Events - PreDeploy is not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
 
@@ -128,11 +90,34 @@ exports.preDeploy = function (serviceContext) {
  * @param {ServiceContext} externalRefServiceContext - The ServiceContext of the external reference for which to get its PreDeployContext
  * @returns {Promise.<PreDeployContext>} - A Promise of the PreDeployContext results from the PreDeploy phase.
  */
-exports.getPreDeployContextForExternalRef = function(externalRefServiceContext) {
-    winston.info(`Lambda - Getting PreDeployContext for external service`);
+exports.getPreDeployContextForExternalRef = function (externalRefServiceContext) {
+    winston.info(`CloudWatch Events - Getting PreDeployContext for external service`);
+    //No pre-deploy, just return empty PreDeployContext
     return Promise.resolve(new PreDeployContext(externalRefServiceContext));
 }
 
+
+/**
+ * Bind two resources from PreDeploy together by performing some wiring action on them. An example * is to add an ingress rule from one security group onto another. Wiring actions may also be
+ * performed in the Deploy phase if there isn't a two-way linkage. For example, security groups
+ * probably need to be done in PreDeploy and Bind, but environment variables from one service to
+ * another can just be done in Deploy
+ *
+ * Bind is run from the perspective of the service being consumed, not the other way around.
+ *
+ * Do not use this phase for creating resources. Those should be done either in PreDeploy or Deploy.
+ * This phase is for wiring up existing resources from PreDeploy
+ *
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being consumed
+ * @param {PreDeployContext} ownPreDeployContext - The PreDeployContext of the service being consumed
+ * @param {ServiceContext} dependentOfServiceContext - The ServiceContext of the service consuming this one
+ * @param {PreDeployContext} dependentOfPreDeployContext - The PreDeployContext of the service consuming this one
+ * @returns {Promise.<BindContext>} - A Promise of the BindContext results from the Bind
+ */
+exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
+    winston.info(`CloudWatch Events - Bind is not required for this service, skipping it`);
+    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+}
 
 /**
  * Returns the BindContext for a service that is referenced externally in your deployed service.
@@ -150,28 +135,10 @@ exports.getPreDeployContextForExternalRef = function(externalRefServiceContext) 
  * @param {PreDeployContext} dependentOfPreDeployContext - The PreDeployContext of the service being deployed that depends on the external service
  * @returns {Promise.<BindContext>} - A Promise of the BindContext results from the Bind
  */
-exports.bind = function(externalRefServiceContext, externalRefPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
-    winston.info(`Lambda - Bind is not required for this service, skipping it`);
-    return Promise.resolve(new BindContext(externalRefServiceContext, dependentOfServiceContext));
-}
-
-/**
- * Returns the BindContext for the service. If Bind has not been run yet for
- * this service against the external consuming service, this method should return an error.
- * 
- * This is used by external references to get information about the Bind phase of 
- * an external service.
- *
- * @param {ServiceContext} externalRefServiceContext - The ServiceContext of the external reference service
- * @param {PreDeployContext} externalRefPreDeployContext - The PreDeployContext of the external reference service * 
- * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being consumed
- * @param {PreDeployContext} ownPreDeployContext - The PreDeployContext of the service being consumed
- * @returns {Promise.<BindContext>} - A Promise of the BindContext results from the Bind
- */
-exports.getBindContextForExternalRef = function(ownServiceContext, ownPreDeployContext, externalRefServiceContext, externalRefPreDeployContext) {
-    winston.info(`Lambda - Getting BindContext for external service`);
+exports.getBindContextForExternalRef = function (externalRefServiceContext, externalRefPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
+    winston.info(`CloudWatch Events - Getting BindContext for external service`);
     //No bind, so just return empty bind context
-    return Promise.resolve(new BindContext(ownServiceContext, externalRefServiceContext));
+    return Promise.resolve(new BindContext(externalRefServiceContext, dependentOfServiceContext));
 }
 
 
@@ -187,30 +154,24 @@ exports.getBindContextForExternalRef = function(ownServiceContext, ownPreDeployC
  */
 exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     let stackName = deployersCommon.getResourceName(ownServiceContext);
-    winston.info(`Lambda - Executing Deploy on ${stackName}`);
+    winston.info(`CloudWatch Events - Deploying CloudWatch Events Rule ${stackName}`);
 
-    return deployersCommon.createCustomRoleForService('lambda.amazonaws.com', getPolicyStatementsForLambdaRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
-        .then(customRole => {
-            return uploadDeployableArtifactToS3(ownServiceContext)
-                .then(s3ArtifactInfo => {
-                    return getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, customRole, s3ArtifactInfo);
-                });
-        })
-        .then(compiledLambdaTemplate => {
+    return getCompiledEventRuleTemplate(stackName, ownServiceContext)
+        .then(eventRuleTemplate => {
             return cloudFormationCalls.getStack(stackName)
                 .then(stack => {
                     if (!stack) {
-                        winston.info(`Lambda - Creating Lambda function ${stackName}`);
-                        return cloudFormationCalls.createStack(stackName, compiledLambdaTemplate, []);
+                        winston.info(`CloudWatch Events - Creating CloudWatch Events Rule ${stackName}`);
+                        return cloudFormationCalls.createStack(stackName, eventRuleTemplate, []);
                     }
                     else {
-                        winston.info(`Lambda - Updating Lambda function ${stackName}`);
-                        return cloudFormationCalls.updateStack(stackName, compiledLambdaTemplate, []);
+                        winston.info(`CloudWatch Events - Updating CloudWatch Events Rule ${stackName}`);
+                        return cloudFormationCalls.updateStack(stackName, eventRuleTemplate, []);
                     }
                 })
         })
         .then(deployedStack => {
-            winston.info(`Lambda - Finished deploying Lambda function ${stackName}`);
+            winston.info(`CloudWatchEvents - Finished deploying CloudWatch Events Rule ${stackName}`);
             return getDeployContext(ownServiceContext, deployedStack);
         });
 }
@@ -227,12 +188,12 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
  * @param {ServiceContext} externalRefServiceContext - The ServiceContext of the external service for which to get the DeployContext
  * @returns {Promise.<DeployContext>} - A Promise of the DeployContext from this deploy
  */
-exports.getDeployContextForExternalRef = function(externalRefServiceContext) {
-    winston.info(`Lambda - Getting DeployContext for external reference`);
+exports.getDeployContextForExternalRef = function (externalRefServiceContext) {
+    winston.info(`CloudWatch Events - Getting DeployContext for external reference`);
     let externalRefStackName = deployersCommon.getResourceName(externalRefServiceContext);
     return cloudFormationCalls.getStack(externalRefStackName)
         .then(externalRefStack => {
-            if(externalRefStack) {
+            if (externalRefStack) {
                 return getDeployContext(externalRefServiceContext, externalRefStack);
             }
             else {
@@ -261,31 +222,7 @@ exports.getDeployContextForExternalRef = function(externalRefServiceContext) {
  * @returns {Promise.<ConsumeEventsContext>} - The information about the event consumption for this service
  */
 exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    //TODO - DynamoDB streams will differ from this model
-    return new Promise((resolve, reject) => {
-        winston.info(`Lambda - Consuming events from service '${producerServiceContext.serviceName}' for service '${ownServiceContext.serviceName}'`);
-        let functionName = ownDeployContext.eventOutputs.lambdaName;
-        let producerServiceType = producerServiceContext.serviceType;
-        let principal;
-        let sourceArn;
-        if (producerServiceType === 'sns') {
-            principal = producerDeployContext.eventOutputs.principal;
-            sourceArn = producerDeployContext.eventOutputs.topicArn;
-        }
-        else if(producerServiceType === 'cloudwatchevent') {
-            principal = producerDeployContext.eventOutputs.principal;
-            sourceArn = producerDeployContext.eventOutputs.eventRuleArn;
-        }
-        else {
-            return reject(new Error(`Lambda - Unsupported event producer type given: ${producerServiceType}`));
-        }
-
-        return lambdaCalls.addLambdaPermissionIfNotExists(functionName, principal, sourceArn)
-            .then(permissionStatement => {
-                winston.info(`Lambda - Allowed consuming events from ${producerServiceContext.serviceName} for ${ownServiceContext.serviceName}`);
-                return resolve(new ConsumeEventsContext(ownServiceContext, producerServiceContext));
-            });
-    });
+    return Promise.reject(new Error("The CloudWatch Events service doesn't consume events from other services"));
 }
 
 /**
@@ -303,35 +240,10 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
  * @param {DeployContext} externalRefDeployContext - The DeployContext of the service that is producing events for this service
  * @returns {Promise.<ConsumeEventsContext>} - The information about the event consumption for this service
  */
-exports.getConsumeEventsContextForExternalRef = function(ownServiceContext, ownDeployContext, externalRefServiceContext, externalRefDeployContext) {
-    return new Promise((resolve, reject) => {
-        winston.info(`Lambda - Getting ConsumeEventsContext for service ${ownServiceContext.serviceName}`);
-        let functionName = ownDeployContext.eventOutputs.lambdaName;
-        let producerServiceType = externalRefServiceContext.serviceType;
-        let principal;
-        let sourceArn;
-        if (producerServiceType === 'sns') {
-            principal = externalRefDeployContext.eventOutputs.principal;
-            sourceArn = externalRefDeployContext.eventOutputs.topicArn;
-        }
-        else if(producerServiceType === 'cloudwatchevent') {
-            principal = externalRefDeployContext.eventOutputs.principal;
-            sourceArn = externalRefDeployContext.eventOutputs.eventRuleArn;
-        }
-        else {
-            return reject(new Error(`Lambda - Unsupported event producer type given: ${producerServiceType}`));
-        }
+exports.getConsumeEventsContextForExternalRef = function (ownServiceContext, ownDeployContext, externalRefServiceContext, externalRefDeployContext) {
+    return Promise.reject(new Error("The CloudWatch Events service doesn't consume events from other services"));
+}
 
-
-        lambdaCalls.getLambdaPermission(functionName, principal, sourceArn)
-            .then(permissionStatement => {
-                if(permissionStatement) {
-                    return resolve(new ConsumeEventsContext(ownServiceContext, externalRefServiceContext));
-                }
-                return reject(new Error(`Lambda - ConsumeEvents not run for external service`));
-            });
-    });
-}   
 
 /**
  * In this phase, this service should make any changes necessary to allow it to produce events to the consumer service.
@@ -352,7 +264,32 @@ exports.getConsumeEventsContextForExternalRef = function(ownServiceContext, own
  * @returns {Promise.<ProduceEventsContext>} - The information about the event consumption for this service
  */
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The Lambda service doesn't produce events for other services"));
+    return new Promise((resolve, reject) => {
+        winston.info(`CloudWatch Events - Producing events from '${ownServiceContext.serviceName}' for consumer ${consumerServiceContext.serviceName}`);
+
+        let ruleName = deployersCommon.getResourceName(ownServiceContext);
+        let consumerServiceType = consumerServiceContext.serviceType;
+        let targetId = deployersCommon.getResourceName(consumerServiceContext);
+        let targetArn;
+        let input;
+        if(consumerServiceType === 'lambda') {
+            targetArn = consumerDeployContext.eventOutputs.lambdaArn;
+            let eventConsumerConfig = deployersCommon.getEventConsumerConfigParams(ownServiceContext, consumerServiceContext);
+            if(!eventConsumerConfig) { throw new Error(`No event_consumer config found in producer service for '${consumerServiceContext.serviceName}'`); }
+            input = eventConsumerConfig.event_input;
+        }
+        else {
+            return reject(new Error(`CloudWatch Events - Unsupported event consumer type given: ${consumerServiceType}`));
+        }
+
+        cloudWatchEventsCalls.addTarget(ruleName, targetArn, targetId, input)
+            .then(targetId => {
+                winston.info(`CloudWatch Events - Configured production of events from '${ownServiceContext.serviceName}' for consumer '${consumerServiceContext.serviceName}'`)
+                return resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
+            });
+    });
+
+
 }
 
 /**
@@ -360,8 +297,9 @@ exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerS
  * 
  * If the list is empty, this service cannot produce events to other services.
  */
-exports.producedEventsSupportedServices = [];
-
+exports.producedEventsSupportedServices = [
+    'lambda'
+];
 
 /**
  * The list of output types that this service produces. 
@@ -379,7 +317,4 @@ exports.producedDeployOutputTypes = [];
  * 
  * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
  */
-exports.consumedDeployOutputTypes = [
-    'environmentVariables',
-    'policies'
-];
+exports.consumedDeployOutputTypes = [];

--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -186,3 +186,14 @@ exports.getAppSecretsAccessPolicyStatements = function (serviceContext) {
 exports.getResourceName = function (serviceContext) {
     return `${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}-${serviceContext.serviceType}`;
 }
+
+
+exports.getEventConsumerConfigParams = function(producerServiceContext, consumerServiceContext) {
+    let consumerServiceName = consumerServiceContext.serviceName;
+    for(let eventConsumerConfig of producerServiceContext.params.event_consumers) {
+        if(eventConsumerConfig.service_name === consumerServiceName) {
+            return eventConsumerConfig;
+        }
+    }
+    return null; //Return null if nothing found for the consumer service in the producer service config
+}

--- a/test/aws/cloudwatch-events-calls-test.js
+++ b/test/aws/cloudwatch-events-calls-test.js
@@ -1,0 +1,29 @@
+const accountConfig = require('../../lib/util/account-config')(`${__dirname}/../test-account-config.yml`).getAccountConfig();
+const expect = require('chai').expect;
+const AWS = require('aws-sdk-mock');
+const cloudWatchEventsCalls = require('../../lib/aws/cloudwatch-events-calls');
+const sinon = require('sinon');
+
+describe('cloudWatchEventsCalls', function() {
+    let sandbox;
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('addTarget', function() {
+        it('should add the requested target to the given rule', function() {
+            AWS.mock('CloudWatchEvents', 'putTargets', Promise.resolve({}));
+            
+            let targetId = "FakeTargetId";
+            return cloudWatchEventsCalls.addTarget("FakeRule", "FakeTargetArn", targetId, '{some: param}')
+                .then(retTargetId => {
+                    expect(retTargetId).to.equal(targetId);
+                });
+        });
+    });
+});

--- a/test/services/cloudwatchevent/cloudwatchevent-test.js
+++ b/test/services/cloudwatchevent/cloudwatchevent-test.js
@@ -1,0 +1,247 @@
+const accountConfig = require('../../../lib/util/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
+const cloudWatchEvent = require('../../../lib/services/cloudwatchevent');
+const cloudFormationCalls = require('../../../lib/aws/cloudformation-calls');
+const cloudWatchEventsCalls = require('../../../lib/aws/cloudwatch-events-calls');
+const ServiceContext = require('../../../lib/datatypes/service-context');
+const ProduceEventsContext = require('../../../lib/datatypes/produce-events-context');
+const DeployContext = require('../../../lib/datatypes/deploy-context');
+const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
+const BindContext = require('../../../lib/datatypes/bind-context');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('cloudwatchevent deployer', function() {
+    let sandbox;
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        sandbox.restore();
+    });
+
+    describe('check', function() {
+        it('should require the schedule or event_pattern parameter to be present', function() {
+            let serviceContext = {
+                params: { }
+            }
+            let errors = cloudWatchEvent.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("You must specify at least one of the 'schedule' or 'event_pattern' parameters");
+        });
+
+        it('should work when there are no configuration errors', function() {
+            let serviceContext = {
+                params: {
+                    schedule: 'rate(1 minute)'
+                }
+            }
+            let errors = cloudWatchEvent.check(serviceContext);
+            expect(errors.length).to.equal(0);
+        });
+    });
+
+    describe('preDeploy', function() {
+        it('should return an empty predeploy context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return cloudWatchEvent.preDeploy(serviceContext)
+                .then(preDeployContext => {
+                    expect(preDeployContext).to.be.instanceof(PreDeployContext);
+                });
+        });
+    });
+
+    describe('getPreDeployContextForExternalRef', function() {
+        it('should return an empty preDeployContext', function() {
+            let externalRefServiceContext = new ServiceContext("FakeName", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return cloudWatchEvent.getPreDeployContextForExternalRef(externalRefServiceContext)
+                .then(externalRefPreDeployContext => {
+                    expect(externalRefPreDeployContext).to.be.instanceof(PreDeployContext);
+                });
+        })
+    });
+
+    describe('bind', function() {
+        it('should return an empty bind context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return cloudWatchEvent.bind(serviceContext)
+                .then(bindContext => {
+                    expect(bindContext).to.be.instanceof(BindContext);
+                });
+        });
+    });
+    
+    describe('getBindContextForExternalRef', function() {
+        it('should return an empty bind context', function() {
+            return cloudWatchEvent.getBindContextForExternalRef(null, null, null, null)
+                .then(externalBindContext => {
+                    expect(externalBindContext).to.be.instanceof(BindContext);
+                });
+        });
+    });
+
+    describe('deploy', function() {
+        let appName = "FakeApp";
+        let envName = "FakeEnv";
+        let deployVersion = "1";
+        let serviceContext = new ServiceContext(appName, envName, "FakeService", "cloudwatchevent", deployVersion, {
+            schedule: 'rate(1 minute)'
+        });
+        let preDeployContext = new PreDeployContext(serviceContext);
+        let eventRuleArn = "FakeEventRuleArn";
+
+        it('should create a new rule when it doesnt exist', function() {
+            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve(null));
+            let createStackStub = sandbox.stub(cloudFormationCalls, 'createStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: 'EventRuleArn',
+                    OutputValue: eventRuleArn
+                }]
+            }));
+
+            return cloudWatchEvent.deploy(serviceContext, preDeployContext, [])
+                .then(deployContext => {
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(createStackStub.calledOnce).to.be.true;
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                    expect(deployContext.eventOutputs.principal).to.equal("events.amazonaws.com");
+                    expect(deployContext.eventOutputs.eventRuleArn).to.equal(eventRuleArn);
+                });
+        });
+
+        it('should update an existing rule when it exists', function() {
+            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({}));
+            let updateStackStub = sandbox.stub(cloudFormationCalls, 'updateStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: 'EventRuleArn',
+                    OutputValue: eventRuleArn
+                }]
+            }));
+
+            return cloudWatchEvent.deploy(serviceContext, preDeployContext, [])
+                .then(deployContext => {
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(updateStackStub.calledOnce).to.be.true;
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                    expect(deployContext.eventOutputs.principal).to.equal("events.amazonaws.com");
+                    expect(deployContext.eventOutputs.eventRuleArn).to.equal(eventRuleArn);
+                });
+        });
+    });
+
+    describe('getDeployContextForExternalRef', function() {
+        it('should return a DeployContext if the service has been deployed', function() {
+            let eventRuleArn = "FakeEventRuleArn";
+            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({
+                Outputs: [{
+                    OutputKey: 'EventRuleArn',
+                    OutputValue: eventRuleArn
+                }]
+            }));
+            let externalServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "cloudwatchevent", "1", {});            
+            return cloudWatchEvent.getDeployContextForExternalRef(externalServiceContext)
+                .then(externalDeployContext => {
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(externalDeployContext).to.be.instanceof(DeployContext);
+                    expect(externalDeployContext.eventOutputs.principal).to.equal("events.amazonaws.com");
+                    expect(externalDeployContext.eventOutputs.eventRuleArn).to.equal(eventRuleArn);
+                });
+        });
+
+        it('should return an error if the service hasnt been deployed yet', function() {
+            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve(null));
+            let externalServiceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "cloudwatchevent", "1", {});            
+            return cloudWatchEvent.getDeployContextForExternalRef(externalServiceContext)
+                .then(externalDeployContext => {
+                    expect(true).to.equal(false); //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain('You must deploy it independently');
+                    expect(getStackStub.calledOnce).to.be.true;
+                });
+        });
+    });
+
+    describe('consumeEvents', function() {
+        it('should return an error since it cant consume events', function() {
+            return cloudWatchEvent.consumeEvents(null, null, null, null)
+                .then(() => {
+                    expect(true).to.be.false; //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("CloudWatch Events service doesn't consume events");
+                });
+        });
+    });
+
+    describe('getConsumeEventsContextForExternalRef', function() {
+        it('should throw an error because S3 cant consume event services', function() {
+            return cloudWatchEvent.getConsumeEventsContextForExternalRef(null, null, null, null)
+                .then(externalConsumeEventsContext => {
+                    expect(true).to.be.false; //Shouldnt get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("CloudWatch Events service doesn't consume events");
+                });
+        });
+    });
+
+
+    describe('produceEvents', function() {
+        let appName = "FakeApp";
+        let envName = "FakeEnv";
+        let deployVersion = "1";
+
+        it('should add a target for the lambda service type', function() {
+            let consumerServiceName = "ConsumerService";
+            let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "lambda", deployVersion, {});
+            let consumerDeployContext = new DeployContext(consumerServiceContext);
+            consumerDeployContext.lambdaArn = "FakeLambdaArn";
+
+            let producerServiceContext = new ServiceContext(appName, envName, "ProducerService", "cloudwatchevent", deployVersion, {
+                event_consumers: [
+                    {
+                        service_name: consumerServiceName,
+                        input: '{"notify": false}'
+                    }
+                ]
+            });
+            let producerDeployContext = new DeployContext(producerServiceContext);
+
+            let addTargetStub = sandbox.stub(cloudWatchEventsCalls, 'addTarget').returns(Promise.resolve("FakeTargetId"));
+
+            return cloudWatchEvent.produceEvents(producerServiceContext, producerDeployContext, consumerServiceContext, consumerDeployContext)
+                .then(produceEventsContext => {
+                    expect(produceEventsContext).to.be.instanceof(ProduceEventsContext);
+                    expect(addTargetStub.calledOnce).to.be.truel
+                });
+        });
+        
+        it('should throw an error for an unsupported consumer service type', function() {
+            let consumerServiceName = "ConsumerService";
+            let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "dynamodb", deployVersion, {});
+            let consumerDeployContext = new DeployContext(consumerServiceContext);
+
+            let producerServiceContext = new ServiceContext(appName, envName, "ProducerService", "cloudwatchevent", deployVersion, {
+                event_consumers: [
+                    {
+                        service_name: consumerServiceName
+                    }
+                ]
+            });
+            let producerDeployContext = new DeployContext(producerServiceContext);
+
+            let addTargetStub = sandbox.stub(cloudWatchEventsCalls, 'addTarget').returns(Promise.resolve("FakeTargetId"));
+
+            return cloudWatchEvent.produceEvents(producerServiceContext, producerDeployContext, consumerServiceContext, consumerDeployContext)
+                .then(produceEventsContext => {
+                    expect(true).to.be.false; //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("Unsupported event consumer type");
+                    expect(addTargetStub.notCalled).to.be.true;
+                });
+        });
+    });
+});

--- a/test/services/deployers-common-test.js
+++ b/test/services/deployers-common-test.js
@@ -310,4 +310,45 @@ describe('deployers-common', function() {
             expect(policyStatements[1].Resource).to.contain(`parameter/${appName}-${envName}-${serviceName}*`)
         });
     });
+
+    describe('getEventConsumerConfigParams', function() {
+        it('should return the config for the consumer from the producer', function() {
+            let appName = "FakeApp";
+            let envName = "FakeEnv";
+            let deployVersion = "1";
+            let consumerServiceName = "ConsumerServiceName";
+            let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "lambda", deployVersion, {
+
+            });
+            let producerServiceName = "ProducerServiceName";
+            let eventInputVal = '{"notify": false}';
+            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", deployVersion, {
+                event_consumers: [{
+                    service_name: consumerServiceName,
+                    event_input: eventInputVal
+                }]
+            });
+
+            let eventConsumerConfig = deployersCommon.getEventConsumerConfigParams(producerServiceContext, consumerServiceContext);
+            expect(eventConsumerConfig).to.not.be.null;
+            expect(eventConsumerConfig.event_input).to.equal(eventInputVal);
+        });
+
+        it('should return null when no config exists in the producer for the consumer', function() {
+            let appName = "FakeApp";
+            let envName = "FakeEnv";
+            let deployVersion = "1";
+            let consumerServiceName = "ConsumerServiceName";
+            let consumerServiceContext = new ServiceContext(appName, envName, consumerServiceName, "lambda", deployVersion, {
+
+            });
+            let producerServiceName = "ProducerServiceName";
+            let producerServiceContext = new ServiceContext(appName, envName, producerServiceName, "cloudwatchevent", deployVersion, {
+                event_consumers: []
+            });
+
+            let eventConsumerConfig = deployersCommon.getEventConsumerConfigParams(producerServiceContext, consumerServiceContext);
+            expect(eventConsumerConfig).to.be.null;
+        });
+    });
 });

--- a/test/services/lambda/lambda-test.js
+++ b/test/services/lambda/lambda-test.js
@@ -283,6 +283,28 @@ describe('lambda deployer', function() {
                 });
         });
 
+        it('should add permissions for the cloudwatchevent service type', function() {
+            let appName = "FakeApp";
+            let envName = "FakeEnv";
+            let deployVersion = "1";
+            let ownServiceContext = new ServiceContext(appName, envName, "consumerService", "lambda", deployVersion, {});
+            let ownDeployContext = new DeployContext(ownServiceContext);
+            ownDeployContext.eventOutputs.lambdaName = "FakeLambda";
+
+            let producerServiceContext = new ServiceContext(appName, envName, "producerService", "cloudwatchevent", deployVersion, {});
+            let producerDeployContext = new DeployContext(producerServiceContext);
+            producerDeployContext.eventOutputs.principal = "FakePrincipal";
+            producerDeployContext.eventOutputs.eventRuleArn = "FakeEventRuleArn";
+
+            let addLambdaPermissionStub = sandbox.stub(lambdaCalls, 'addLambdaPermissionIfNotExists').returns(Promise.resolve({}));
+
+            return lambda.consumeEvents(ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext)
+                .then(consumeEventsContext => {
+                    expect(consumeEventsContext).to.be.instanceof(ConsumeEventsContext);
+                    expect(addLambdaPermissionStub.calledOnce).to.be.true;
+                });
+        });
+
         it('should return an error for any other service type', function() {
             let appName = "FakeApp";
             let envName = "FakeEnv";

--- a/test/services/s3/s3-test.js
+++ b/test/services/s3/s3-test.js
@@ -8,7 +8,7 @@ const BindContext = require('../../../lib/datatypes/bind-context');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
-describe('efs deployer', function() {
+describe('s3 deployer', function() {
     let sandbox;
 
     beforeEach(function() {
@@ -104,6 +104,8 @@ describe('efs deployer', function() {
 
             return s3.deploy(serviceContext, preDeployContext, [])
                 .then(deployContext => {
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(createStackStub.calledOnce).to.be.true;
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.policies.length).to.equal(2);
                     expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_BUCKET_NAME"]).to.equal(bucketName);
@@ -123,6 +125,8 @@ describe('efs deployer', function() {
 
             return s3.deploy(serviceContext, preDeployContext, [])
                 .then(deployContext => {
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(updateStackStub.calledOnce).to.be.true;
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.policies.length).to.equal(2);
                     expect(deployContext.environmentVariables["S3_FAKEAPP_FAKEENV_FAKESERVICE_BUCKET_NAME"]).to.equal(bucketName);


### PR DESCRIPTION
This adds support for CloudWatch Events, only supporting producing
events to the lambda service. Other services like SNS can be added
on an as-needed basis.

Resolves #64 
Resolves #62 