### PR TITLE
Update parameter store access to allow the entire app namespace

### DIFF
--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -177,7 +177,7 @@ exports.getAppSecretsAccessPolicyStatements = function (serviceContext) {
             Action: [
                 "ssm:GetParameters"
             ],
-            Resource: `arn:aws:ssm:${accountConfig.region}:${accountConfig.account_id}:parameter/${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}*`
+            Resource: `arn:aws:ssm:${accountConfig.region}:${accountConfig.account_id}:parameter/${serviceContext.appName}*`
         }
     ]
 }

--- a/test/services/deployers-common-test.js
+++ b/test/services/deployers-common-test.js
@@ -307,7 +307,7 @@ describe('deployers-common', function() {
             let serviceContext = new ServiceContext(appName, envName, serviceName, "lambda", "1", {});
             let policyStatements = deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext);
             expect(policyStatements.length).to.equal(2);
-            expect(policyStatements[1].Resource).to.contain(`parameter/${appName}-${envName}-${serviceName}*`)
+            expect(policyStatements[1].Resource).to.contain(`parameter/${appName}*`)
         });
     });
 


### PR DESCRIPTION
Previously, we only allowed a service to access its secrets, but
not other services in the same Handel file. This changes opens
up access to any parameter for the app, which would be any parameter
that has a name starting with <appName>.

Resolves #69 
Resolves #70 