### PR TITLE
Serialize produce and consume event lifecycle phases.

### DIFF
--- a/lib/lifecycle/consume-events.js
+++ b/lib/lifecycle/consume-events.js
@@ -2,51 +2,52 @@ const winston = require('winston');
 const _ = require('lodash');
 const ConsumeEventsContext = require('../datatypes/consume-events-context');
 const util = require('../util/util');
+const Promise = require('bluebird');
 
 function consumeInternalEvents(serviceDeployers, environmentContext, deployContexts) {
-    let consumePromises = [];
+    let consumeEventActions = [];
     let consumeEventsContexts = {};
 
     winston.info(`Consuming internal events (if any) for services`);
+
     _.forEach(environmentContext.serviceContexts, function(producerServiceContext, producerServiceName) {
-        if(producerServiceContext.params.event_consumers) {
+        if(producerServiceContext.params.event_consumers) { //Only look at those services producing events
             _.forEach(producerServiceContext.params.event_consumers, function(consumerService) {
                 let consumerServiceName = consumerService.service_name;
 
                 if(!consumerServiceName.startsWith('https://')) { //Don't look at external service references
-                    //Get deploy info for producer service
-                    let producerDeployContext = deployContexts[producerServiceName];
-                    
-                    //Get deploy info for consumer service
-                    
                     let consumerServiceContext = environmentContext.serviceContexts[consumerServiceName];
-                    let consumerDeployContext = deployContexts[consumerServiceName];
-                    let consumerServiceDeployer = serviceDeployers[consumerServiceContext.serviceType];
-                    
-                    //Execute consume on consumer service
-                    let consumeEventsContextName = util.getConsumeEventsContextName(consumerServiceName, producerServiceName);
-                    winston.info(`Consuming events from internal service ${consumeEventsContextName}`);
-                    let consumePromise = consumerServiceDeployer.consumeEvents(consumerServiceContext, consumerDeployContext, producerServiceContext, producerDeployContext)
-                        .then(consumeEventsContext => {
-                            if(!(consumeEventsContext instanceof ConsumeEventsContext)) {
-                                throw new Error("Expected ConsumeEventsContext back from 'consumeEvents' phase of service deployer");
-                            }
-                            consumeEventsContexts[consumeEventsContextName] = consumeEventsContext;
-                        });
-                    consumePromises.push(consumePromise);
+                    consumeEventActions.push({
+                        consumerServiceContext,
+                        consumerDeployContext: deployContexts[consumerServiceName],
+                        consumerServiceDeployer: serviceDeployers[consumerServiceContext.serviceType],
+                        producerServiceContext,
+                        producerDeployContext: deployContexts[producerServiceName]
+                    });
                 }
             });
         }
     });
 
-    return Promise.all(consumePromises)
-        .then(() => {
-            return consumeEventsContexts; //This was built-up dynamically above
-        });
+    return Promise.mapSeries(consumeEventActions, action => {
+        let consumeEventsContextName = util.getConsumeEventsContextName(action.consumerServiceContext.serviceName, action.producerServiceContext.serviceName);
+        winston.info(`Consuming events from internal service ${consumeEventsContextName}`);
+        return action.consumerServiceDeployer.consumeEvents(action.consumerServiceContext, action.consumerDeployContext, action.producerServiceContext, action.producerDeployContext)
+            .then(consumeEventsContext => {
+                if(!(consumeEventsContext instanceof ConsumeEventsContext)) {
+                    throw new Error("Expected ConsumeEventsContext back from 'consumeEvents' phase of service deployer");
+                }
+
+                consumeEventsContexts[consumeEventsContextName] = consumeEventsContext;
+            });
+    })
+    .then(() => {
+        return consumeEventsContexts; //This was built-up dynamically above
+    });
 }
 
 function consumeExternalEvents(serviceDeployers, environmentContext, deployContexts) {
-    let externalConsumePromises = [];
+    let externalConsumeEventActions = [];
     let externalConsumeEventsContexts = {};
 
     winston.info(`Consuming external events (if any) for services`);
@@ -56,32 +57,42 @@ function consumeExternalEvents(serviceDeployers, environmentContext, deployConte
             let serviceDeployer = serviceDeployers[consumerServiceContext.serviceType];
 
             for(let externalServiceName of consumerServiceContext.params.external_event_producers) {
-                let consumeEventsContextName = util.getConsumeEventsContextName(consumerServiceName, externalServiceName);
-                winston.info(`Consuming events from external service ${consumeEventsContextName}`);
-                let externalConsumePromise = util.getExternalServiceContext(externalServiceName, "1")
-                    .then(externalServiceContext => {
-                        let externalServiceDeployer = serviceDeployers[externalServiceContext.serviceType];
-                        return externalServiceDeployer.getDeployContextForExternalRef(externalServiceContext)
-                            .then(externalDeployContext => {
-                                return serviceDeployer.consumeEvents(consumerServiceContext, consumerDeployContext, externalServiceContext, externalDeployContext)
-                            });
-                    })
-                    .then(consumeEventsContext => {
-                        if(!(consumeEventsContext instanceof ConsumeEventsContext)) {
-                            throw new Error("Expected ConsumeEventsContext back from 'consumeEvents' phase of service deployer");
-                        }
-                        externalConsumeEventsContexts[consumeEventsContextName] = consumeEventsContext;
-                    });
-                
-                externalConsumePromises.push(externalConsumePromise);
+                externalConsumeEventActions.push({
+                    consumerServiceContext: consumerServiceContext,
+                    consumerDeployContext: consumerDeployContext,
+                    externalServiceName: externalServiceName,
+                    serviceDeployer: serviceDeployer
+                });
             }
         }
     });
 
-    return Promise.all(externalConsumePromises)
-        .then(() => {
-            return externalConsumeEventsContexts; //This was built-up dynamically above
-        });
+    return Promise.mapSeries(externalConsumeEventActions, externalEventAction => {
+        let consumerServiceContext = externalEventAction.consumerServiceContext;
+        let consumerDeployContext = externalEventAction.consumerDeployContext;
+        let externalServiceName = externalEventAction.externalServiceName;
+        let serviceDeployer = externalEventAction.serviceDeployer;
+
+        let consumeEventsContextName = util.getConsumeEventsContextName(consumerServiceContext.serviceName, externalServiceName);
+        winston.info(`Consuming events from external service ${consumeEventsContextName}`);
+        return util.getExternalServiceContext(externalServiceName, "1")
+            .then(externalServiceContext => {
+                let externalServiceDeployer = serviceDeployers[externalServiceContext.serviceType];
+                return externalServiceDeployer.getDeployContextForExternalRef(externalServiceContext)
+                    .then(externalDeployContext => {
+                        return serviceDeployer.consumeEvents(consumerServiceContext, consumerDeployContext, externalServiceContext, externalDeployContext)
+                    });
+            })
+            .then(consumeEventsContext => {
+                if(!(consumeEventsContext instanceof ConsumeEventsContext)) {
+                    throw new Error("Expected ConsumeEventsContext back from 'consumeEvents' phase of service deployer");
+                }
+                externalConsumeEventsContexts[consumeEventsContextName] = consumeEventsContext;
+            });
+    })
+    .then(() => {
+        return externalConsumeEventsContexts; //This was built-up dynamically above
+    });
 }
 
 exports.consumeEvents = function(serviceDeployers, environmentContext, deployContexts) {

--- a/lib/lifecycle/produce-events.js
+++ b/lib/lifecycle/produce-events.js
@@ -2,7 +2,7 @@ const winston = require('winston');
 const _ = require('lodash');
 const ProduceEventsContext = require('../datatypes/produce-events-context');
 const util = require('../util/util');
-
+const Promise = require('bluebird');
 
 let produceInternalEvent = function(consumerServiceContext, consumerDeployContext, producerServiceContext, producerDeployContext, producerServiceDeployer) {
     winston.info(`Producing events from ${producerServiceContext.serviceName} for internal service ${consumerServiceContext.serviceName}`);
@@ -44,7 +44,7 @@ let produceExternalEvent = function(producerServiceContext, producerDeployContex
 exports.produceEvents = function(serviceDeployers, environmentContext, deployContexts) {
     winston.info(`Executing produce events phase on services in environment ${environmentContext.environmentName}`);
 
-    let producePromises = [];
+    let produceEventActions = [];
     let produceEventsContexts = {};
 
     _.forEach(environmentContext.serviceContexts, function(producerServiceContext, producerServiceName) {
@@ -56,32 +56,37 @@ exports.produceEvents = function(serviceDeployers, environmentContext, deployCon
                 
                 //Get deploy info for consumer service
                 let consumerServiceName = consumerService.service_name;
-                let produceEventsContextName = util.getProduceEventsContextName(producerServiceName, consumerServiceName);
-                if(consumerServiceName.startsWith("https://")) { //External dependency
-                    let producePromise = produceExternalEvent(producerServiceContext, producerDeployContext, consumerServiceName, serviceDeployers)
-                        .then(produceEventsContext => {
-                            produceEventsContexts[produceEventsContextName] = produceEventsContext;
-                        });
-                    
-                    producePromises.push(producePromise);
-                }
-                else { //Internal dependency
-                    let consumerServiceContext = environmentContext.serviceContexts[consumerServiceName];
-                    let consumerDeployContext = deployContexts[consumerServiceName];
-
-                    let producePromise = produceInternalEvent(consumerServiceContext, consumerDeployContext, producerServiceContext, producerDeployContext, producerServiceDeployer)
-                        .then(produceEventsContext => {
-                            produceEventsContexts[produceEventsContextName] = produceEventsContext;
-                        });
-
-                    producePromises.push(producePromise);
-                }
+                
+                produceEventActions.push({
+                    consumerServiceName,
+                    producerServiceContext,
+                    producerDeployContext,
+                    producerServiceDeployer
+                });
             });
         }
     });
 
-    return Promise.all(producePromises)
-        .then(() => {
-            return produceEventsContexts; //This was built-up dynamically above
-        });
+    return Promise.mapSeries(produceEventActions, action => {
+        let produceEventsContextName = util.getProduceEventsContextName(action.producerServiceContext.serviceName, action.consumerServiceName);
+
+        if(action.consumerServiceName.startsWith("https://")) { //External dependency
+            return produceExternalEvent(action.producerServiceContext, action.producerDeployContext, action.consumerServiceName, serviceDeployers)
+                .then(produceEventsContext => {
+                    produceEventsContexts[produceEventsContextName] = produceEventsContext;
+                });
+        }
+        else { //Internal dependency
+            let consumerServiceContext = environmentContext.serviceContexts[action.consumerServiceName];
+            let consumerDeployContext = deployContexts[action.consumerServiceName];
+
+            return produceInternalEvent(consumerServiceContext, consumerDeployContext, action.producerServiceContext, action.producerDeployContext, action.producerServiceDeployer)
+                .then(produceEventsContext => {
+                    produceEventsContexts[produceEventsContextName] = produceEventsContext;
+                });
+        }
+    })
+    .then(() => {
+        return produceEventsContexts; //This was built-up dynamically above
+    });
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "archiver": "^1.3.0",
     "aws-sdk": "^2.9.0",
+    "bluebird": "^3.5.0",
     "commander": "^2.9.0",
     "handlebars": "^4.0.6",
     "js-yaml": "3.7.0",


### PR DESCRIPTION
Consume events were having race conditions trying to add permissions
to the same lambda. Each would read that there was no policy doc
there, try to add the doc, then one would overwrite the others.

We could try to lock this, but consume and produce run so fast that
there's no reason they can't be serialized.

Resolves #79 