### PR TITLE
Add support for HTTPS in Beanstalk

### DIFF
--- a/docs/supported-services/beanstalk.rst
+++ b/docs/supported-services/beanstalk.rst
@@ -57,6 +57,11 @@ Parameters
      - No
      - 1
      - The maximum number of instances that can be in the auto-scale group.
+   * - routing
+     - Routing
+     - No
+     - 
+     - The Routing element details what kind of routing you want to your ECS service (if any)
    * - environment_variables
      - EnvironmentVariables
      - No
@@ -78,6 +83,16 @@ The EnvironmentVariables element is defined by the following schema:
       <YOUR_ENV_NAME>: <your_env_value>
 
 <YOUR_ENV_NAME> is a string that will be the name of the injected environment variable. <your_env_value> is its value. You may specify an arbitrary number of environment variables in this section.
+
+Routing element
+~~~~~~~~~~~~~~~
+The Routing element is defined by the following schema:
+
+.. code-block:: yaml
+    
+    routing:
+      type: <http|https>
+      https_certificate # Required if you select https as the routing type
 
 Tags element
 ~~~~~~~~~~~~

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -55,19 +55,6 @@ function getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependencie
     let provisionedMemory = serviceParams.provisioned_memory || "128";
     let functionTimeout = serviceParams.function_timeout || "3";
 
-    // return {
-    //     ApiName: stackName,
-    //     LambdaRoleArn: executionRole.Arn,
-    //     LambdaRuntime: ownServiceContext.params.lambda_runtime,
-    //     ProvisionedMemory: provisionedMemory.toString(),
-    //     HandlerFunction: ownServiceContext.params.handler_function,
-    //     FunctionTimeout: functionTimeout.toString(),
-    //     CodeUriS3Bucket: artifactS3Bucket,
-    //     CodeUriS3Key: artifactS3Key,
-    //     StageName: ownServiceContext.environmentName
-    // }
-
-
     let handlebarsParams = {
         stageName: ownServiceContext.environmentName,
         s3Bucket: s3ObjectInfo.Bucket,

--- a/lib/services/beanstalk/beanstalk-instance-role-statements.json
+++ b/lib/services/beanstalk/beanstalk-instance-role-statements.json
@@ -1,0 +1,52 @@
+[
+    {
+        "Sid": "BucketAccess",
+        "Action": [
+            "s3:Get*",
+            "s3:List*",
+            "s3:PutObject"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+            "arn:aws:s3:::elasticbeanstalk-*",
+            "arn:aws:s3:::elasticbeanstalk-*/*"
+        ]
+    },
+    {
+        "Sid": "XRayAccess",
+        "Action": [
+            "xray:PutTraceSegments",
+            "xray:PutTelemetryRecords"
+        ],
+        "Effect": "Allow",
+        "Resource": "*"
+    },
+    {
+        "Sid": "CloudWatchLogsAccess",
+        "Action": [
+            "logs:PutLogEvents",
+            "logs:CreateLogStream"
+        ],
+        "Effect": "Allow",
+        "Resource": [
+            "arn:aws:logs:*:*:log-group:/aws/elasticbeanstalk*"
+        ]
+    },
+    {
+        "Sid": "ECSAccess",
+        "Effect": "Allow",
+        "Action": [
+            "ecs:Poll",
+            "ecs:StartTask",
+            "ecs:StopTask",
+            "ecs:DiscoverPollEndpoint",
+            "ecs:StartTelemetrySession",
+            "ecs:RegisterContainerInstance",
+            "ecs:DeregisterContainerInstance",
+            "ecs:DescribeContainerInstances",
+            "ecs:Submit*",
+            "ecs:DescribeTasks"
+        ],
+        "Resource": "*"
+    }
+]

--- a/lib/services/beanstalk/beanstalk-service-role-statements.json
+++ b/lib/services/beanstalk/beanstalk-service-role-statements.json
@@ -1,0 +1,149 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "elasticloadbalancing:DescribeInstanceHealth",
+            "elasticloadbalancing:DescribeLoadBalancers",
+            "elasticloadbalancing:DescribeTargetHealth",
+            "ec2:DescribeInstances",
+            "ec2:DescribeInstanceStatus",
+            "ec2:GetConsoleOutput",
+            "ec2:AssociateAddress",
+            "ec2:DescribeAddresses",
+            "ec2:DescribeSecurityGroups",
+            "sqs:GetQueueAttributes",
+            "sqs:GetQueueUrl",
+            "autoscaling:DescribeAutoScalingGroups",
+            "autoscaling:DescribeAutoScalingInstances",
+            "autoscaling:DescribeScalingActivities",
+            "autoscaling:DescribeNotificationConfigurations"
+        ],
+        "Resource": [
+            "*"
+        ]
+    },
+    {
+        "Sid": "AllowCloudformationOperationsOnElasticBeanstalkStacks",
+        "Effect": "Allow",
+        "Action": [
+            "cloudformation:*"
+        ],
+        "Resource": [
+            "arn:aws:cloudformation:*:*:stack/awseb-*",
+            "arn:aws:cloudformation:*:*:stack/eb-*"
+        ]
+    },
+    {
+        "Sid": "AllowDeleteCloudwatchLogGroups",
+        "Effect": "Allow",
+        "Action": [
+            "logs:DeleteLogGroup"
+        ],
+        "Resource": [
+            "arn:aws:logs:*:*:log-group:/aws/elasticbeanstalk*"
+        ]
+    },
+    {
+        "Sid": "AllowS3OperationsOnElasticBeanstalkBuckets",
+        "Effect": "Allow",
+        "Action": [
+            "s3:*"
+        ],
+        "Resource": [
+            "arn:aws:s3:::elasticbeanstalk-*",
+            "arn:aws:s3:::elasticbeanstalk-*/*"
+        ]
+    },
+    {
+        "Sid": "AllowOperations",
+        "Effect": "Allow",
+        "Action": [
+            "autoscaling:AttachInstances",
+            "autoscaling:CreateAutoScalingGroup",
+            "autoscaling:CreateLaunchConfiguration",
+            "autoscaling:DeleteLaunchConfiguration",
+            "autoscaling:DeleteAutoScalingGroup",
+            "autoscaling:DeleteScheduledAction",
+            "autoscaling:DescribeAccountLimits",
+            "autoscaling:DescribeAutoScalingGroups",
+            "autoscaling:DescribeAutoScalingInstances",
+            "autoscaling:DescribeLaunchConfigurations",
+            "autoscaling:DescribeLoadBalancers",
+            "autoscaling:DescribeNotificationConfigurations",
+            "autoscaling:DescribeScalingActivities",
+            "autoscaling:DescribeScheduledActions",
+            "autoscaling:DetachInstances",
+            "autoscaling:PutScheduledUpdateGroupAction",
+            "autoscaling:ResumeProcesses",
+            "autoscaling:SetDesiredCapacity",
+            "autoscaling:SuspendProcesses",
+            "autoscaling:TerminateInstanceInAutoScalingGroup",
+            "autoscaling:UpdateAutoScalingGroup",
+            "cloudwatch:PutMetricAlarm",
+            "ec2:AssociateAddress",
+            "ec2:AllocateAddress",
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:CreateSecurityGroup",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DescribeAccountAttributes",
+            "ec2:DescribeAddresses",
+            "ec2:DescribeImages",
+            "ec2:DescribeInstances",
+            "ec2:DescribeKeyPairs",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSnapshots",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeVpcs",
+            "ec2:DisassociateAddress",
+            "ec2:ReleaseAddress",
+            "ec2:RevokeSecurityGroupEgress",
+            "ec2:RevokeSecurityGroupIngress",
+            "ec2:TerminateInstances",
+            "ecs:CreateCluster",
+            "ecs:DeleteCluster",
+            "ecs:DescribeClusters",
+            "ecs:RegisterTaskDefinition",
+            "elasticbeanstalk:*",
+            "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+            "elasticloadbalancing:ConfigureHealthCheck",
+            "elasticloadbalancing:CreateLoadBalancer",
+            "elasticloadbalancing:DeleteLoadBalancer",
+            "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+            "elasticloadbalancing:DescribeInstanceHealth",
+            "elasticloadbalancing:DescribeLoadBalancers",
+            "elasticloadbalancing:DescribeTargetHealth",
+            "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+            "elasticloadbalancing:DescribeTargetGroups",
+            "elasticloadbalancing:RegisterTargets",
+            "elasticloadbalancing:DeregisterTargets",
+            "iam:ListRoles",
+            "iam:PassRole",
+            "logs:CreateLogGroup",
+            "logs:PutRetentionPolicy",
+            "rds:DescribeDBEngineVersions",
+            "rds:DescribeDBInstances",
+            "rds:DescribeOrderableDBInstanceOptions",
+            "s3:CopyObject",
+            "s3:GetObject",
+            "s3:GetObjectAcl",
+            "s3:GetObjectMetadata",
+            "s3:ListBucket",
+            "s3:listBuckets",
+            "s3:ListObjects",
+            "sns:CreateTopic",
+            "sns:GetTopicAttributes",
+            "sns:ListSubscriptionsByTopic",
+            "sns:Subscribe",
+            "sqs:GetQueueAttributes",
+            "sqs:GetQueueUrl",
+            "codebuild:CreateProject",
+            "codebuild:DeleteProject",
+            "codebuild:BatchGetBuilds",
+            "codebuild:StartBuild"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/beanstalk/beanstalk-template.yml
+++ b/lib/services/beanstalk/beanstalk-template.yml
@@ -33,9 +33,9 @@ Resources:
         OptionName: IamInstanceProfile
         Value: !Ref InstanceProfile
       {{#each optionSettings}}
-      - Namespace: {{namespace}}
+      - Namespace: "{{namespace}}"
         OptionName: {{optionName}}
-        Value: {{value}}
+        Value: "{{value}}"
       {{/each}}
       SolutionStackName: {{solutionStack}}
   Environment:

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -9,6 +9,7 @@ const deployersCommon = require('../deployers-common');
 const ec2Calls = require('../../aws/ec2-calls');
 const fs = require('fs');
 const uuid = require('uuid');
+const util = require('../../util/util');
 const _ = require('lodash');
 
 function getEbConfigurationOption(namespace, optionName, value) {
@@ -24,18 +25,18 @@ function getEnvVariablesToInject(serviceContext, dependenciesDeployContexts) {
     let envVarsToInject = deployersCommon.getEnvVarsFromDependencyDeployContexts(dependenciesDeployContexts);
     envVarsToInject = _.assign(envVarsToInject, deployersCommon.getEnvVarsFromServiceContext(serviceContext));
 
-    if(serviceParams.environment_variables) {
+    if (serviceParams.environment_variables) {
         envVarsToInject = _.assign(envVarsToInject, serviceParams.environment_variables);
     }
     return envVarsToInject;
 }
 
 
-function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContext, dependenciesDeployContexts, customRole, s3ArtifactInfo) {
+function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContext, dependenciesDeployContexts, instanceRole, serviceRole, s3ArtifactInfo) {
     let serviceParams = serviceContext.params;
     let handlebarsParams = {
         applicationName: stackName,
-        beanstalkRoleName: customRole.RoleName,
+        beanstalkRoleName: instanceRole.RoleName,
         applicationVersionBucket: s3ArtifactInfo.Bucket,
         applicationVersionKey: s3ArtifactInfo.Key,
         solutionStack: serviceParams.solution_stack,
@@ -49,7 +50,7 @@ function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContex
     handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:autoscaling:asg", "MaxSize", maxInstances));
 
     //Configure launch configuration
-    if(serviceParams.key_name) {
+    if (serviceParams.key_name) {
         handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:autoscaling:launchconfiguration", "EC2KeyName", serviceParams.key_name));
     }
     let instanceType = serviceParams.instance_type || "t2.micro";
@@ -69,13 +70,39 @@ function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContex
 
     //Add environment variables
     let envVarsToInject = getEnvVariablesToInject(serviceContext, dependenciesDeployContexts);
-    for(let envVarName in envVarsToInject) {
+    for (let envVarName in envVarsToInject) {
         handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:application:environment", envVarName, envVarsToInject[envVarName]));
     }
-    //TODO - add healthcheck url and others pas aws:elasticbeanstalk:application
+    
+    //Use enhanced metrics (shouldnt be extra $ unless we specify to send metrics to CloudWatch)
+    handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:healthreporting:system", "SystemType", "enhanced"));
+
+    //Set up routing
+    handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:environment", "LoadBalancerType", "application"));
+    let healthCheckUrl = serviceParams.health_check_url || '/';
+    handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:application", "Application Healthcheck URL", healthCheckUrl));
+    let serviceRoleName = `${serviceRole.Path}${serviceRole.RoleName}`;
+    if(serviceRoleName.startsWith('/')) { //Beanstalk doesnt like the leading slash, it just wants something like services/HandelBeanstalkServiceRole
+        serviceRoleName = serviceRoleName.substr(1); 
+    }
+    handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:environment", "ServiceRole", serviceRoleName));
+    handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elbv2:loadbalancer", "IdleTimeout", "300"));
+    if (serviceParams.routing && serviceParams.routing.type === 'https') { //HTTPS ALB Listener
+        handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elbv2:listener:443", "Protocol", "HTTPS"));
+        let certArn = `	arn:aws:acm:us-west-2:${accountConfig.account_id}:certificate/${serviceParams.routing.https_certificate}`;
+        handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elbv2:listener:443", "SSLCertificateArns", certArn));
+        handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elbv2:listener:default", "ListenerEnabled", "false"));
+        handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:environment:process:default", "HealthCheckPath", healthCheckUrl));
+        handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:environment:process:default", "Port", "80"));
+        handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elasticbeanstalk:environment:process:default", "Protocol", "HTTP"));
+    }
+    else { //HTTP ALB Listener
+        handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elbv2:listener:80", "Protocol", "HTTP"));
+        handlebarsParams.optionSettings.push(getEbConfigurationOption("aws:elbv2:listener:80", "ListenerEnabled", "true"));
+    }
 
     //Add tags (if present)
-    if(serviceParams.tags) {
+    if (serviceParams.tags) {
         handlebarsParams.tags = serviceParams.tags;
     }
 
@@ -91,59 +118,13 @@ function getDeployContext(serviceContext, cfStack) {
  * This returns the policy needed for Beanstalk to work in the web
  * tier, including Docker ECS multi-container support
  */
-function getPolicyStatementForBeanstalkRole(serviceContext) {
-    return [
-        {
-            "Sid": "BucketAccess",
-            "Action": [
-                "s3:Get*",
-                "s3:List*",
-                "s3:PutObject"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-                "arn:aws:s3:::elasticbeanstalk-*",
-                "arn:aws:s3:::elasticbeanstalk-*/*"
-            ]
-        },
-        {
-            "Sid": "XRayAccess",
-            "Action": [
-                "xray:PutTraceSegments",
-                "xray:PutTelemetryRecords"
-            ],
-            "Effect": "Allow",
-            "Resource": "*"
-        },
-        {
-            "Sid": "CloudWatchLogsAccess",
-            "Action": [
-                "logs:PutLogEvents",
-                "logs:CreateLogStream"
-            ],
-            "Effect": "Allow",
-            "Resource": [
-                "arn:aws:logs:*:*:log-group:/aws/elasticbeanstalk*"
-            ]
-        },
-        {
-            "Sid": "ECSAccess",
-            "Effect": "Allow",
-            "Action": [
-                "ecs:Poll",
-                "ecs:StartTask",
-                "ecs:StopTask",
-                "ecs:DiscoverPollEndpoint",
-                "ecs:StartTelemetrySession",
-                "ecs:RegisterContainerInstance",
-                "ecs:DeregisterContainerInstance",
-                "ecs:DescribeContainerInstances",
-                "ecs:Submit*",
-                "ecs:DescribeTasks"
-            ],
-            "Resource": "*"
-        }
-    ].concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+function getPolicyStatementForInstanceRole(serviceContext) {
+    let policyStatements = JSON.parse(util.readFileSync(`${__dirname}/beanstalk-instance-role-statements.json`));
+    return policyStatements.concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+}
+
+function getPolicyStatementForServiceRole() {
+    return JSON.parse(util.readFileSync(`${__dirname}/beanstalk-service-role-statements.json`));
 }
 
 function uploadDeployableArtifactToS3(serviceContext) {
@@ -204,18 +185,18 @@ exports.preDeploy = function (serviceContext) {
  * @param {ServiceContext} externalRefServiceContext - The ServiceContext of the external reference for which to get its PreDeployContext
  * @returns {Promise.<PreDeployContext>} - A Promise of the PreDeployContext results from the PreDeploy phase.
  */
-exports.getPreDeployContextForExternalRef = function(externalRefServiceContext) {
+exports.getPreDeployContextForExternalRef = function (externalRefServiceContext) {
     let sgName = deployersCommon.getResourceName(externalRefServiceContext);
     winston.info(`Beanstalk - Getting PreDeployContext for external reference ${sgName}`);
 
     return ec2Calls.getSecurityGroup(sgName, accountConfig.vpc)
         .then(securityGroup => {
-            if(securityGroup) {
+            if (securityGroup) {
                 let externalPreDeployContext = new PreDeployContext(externalRefServiceContext);
                 externalPreDeployContext.securityGroups.push(securityGroup);
                 return externalPreDeployContext;
             }
-            throw new Error(`Beanstalk - Resources from PreDeploy not found!`); 
+            throw new Error(`Beanstalk - Resources from PreDeploy not found!`);
         });
 }
 
@@ -258,7 +239,7 @@ exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServ
  * @param {PreDeployContext} dependentOfPreDeployContext - The PreDeployContext of the service being deployed that depends on the external service
  * @returns {Promise.<BindContext>} - A Promise of the BindContext results from the Bind
  */
-exports.getBindContextForExternalRef = function(externalRefServiceContext, externalRefPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
+exports.getBindContextForExternalRef = function (externalRefServiceContext, externalRefPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
     winston.info(`Beanstalk - Getting BindContext for external reference`);
     //No bind, so just return empty bind context
     return Promise.resolve(new BindContext(externalRefServiceContext, dependentOfServiceContext));
@@ -279,11 +260,14 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`Beanstalk - Executing Deploy on ${stackName}`);
 
-    return deployersCommon.createCustomRoleForService('ec2.amazonaws.com', getPolicyStatementForBeanstalkRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
-        .then(customRole => {
-            return uploadDeployableArtifactToS3(ownServiceContext)
-                .then(s3ArtifactInfo => {
-                    return getCompiledBeanstalkTemplate(stackName, ownPreDeployContext, ownServiceContext, dependenciesDeployContexts, customRole, s3ArtifactInfo);
+    return deployersCommon.createCustomRoleForService('ec2.amazonaws.com', getPolicyStatementForInstanceRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
+        .then(instanceRole => {
+            return deployersCommon.createCustomRole('elasticbeanstalk.amazonaws.com', 'HandelBeanstalkServiceRole', getPolicyStatementForServiceRole())
+                .then(serviceRole => {
+                    return uploadDeployableArtifactToS3(ownServiceContext)
+                        .then(s3ArtifactInfo => {
+                            return getCompiledBeanstalkTemplate(stackName, ownPreDeployContext, ownServiceContext, dependenciesDeployContexts, instanceRole, serviceRole, s3ArtifactInfo);
+                        });
                 });
         })
         .then(compiledBeanstalkTemplate => {
@@ -317,12 +301,12 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
  * @param {ServiceContext} externalRefServiceContext - The ServiceContext of the external service for which to get the DeployContext
  * @returns {Promise.<DeployContext>} - A Promise of the DeployContext from this deploy
  */
-exports.getDeployContextForExternalRef = function(externalRefServiceContext) {
+exports.getDeployContextForExternalRef = function (externalRefServiceContext) {
     winston.info(`Beanstalk - Getting DeployContext for external reference`);
     let externalRefStackName = deployersCommon.getResourceName(externalRefServiceContext);
     return cloudFormationCalls.getStack(externalRefStackName)
         .then(externalStack => {
-            if(externalStack) {
+            if (externalStack) {
                 return getDeployContext(externalRefServiceContext, externalStack);
             }
             throw new Error(`Beanstalk - Stack ${externalRefStackName} is not deployed!`);
@@ -367,8 +351,8 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
  * @param {DeployContext} externalRefDeployContext - The DeployContext of the service that is producing events for this service
  * @returns {Promise.<ConsumeEventsContext>} - The information about the event consumption for this service
  */
-exports.getConsumeEventsContextForExternalRef = function(ownServiceContext, ownDeployContext, externalRefServiceContext, externalRefDeployContext) {
-    return Promise.reject(new Error("The Beanstalk service doesn't consume events from other services"));
+exports.getConsumeEventsContextForExternalRef = function (ownServiceContext,  ownDeployContext, externalRefServiceContext, externalRefDeployContext) {
+    return  Promise.reject(new Error("The Beanstalk service doesn't consume events from other services"));
 }
 
 /**

--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -37,22 +37,7 @@ exports.getEnvVarsFromDependencyDeployContexts = function (deployContexts) {
     return envVars;
 }
 
-exports.createCustomRoleForService = function (trustedService, ownServicePolicyStatements, ownServiceContext, dependenciesDeployContexts) {
-    let policyStatementsToConsume = [];
-
-    //Add policies from dependencies that have them
-    for (let deployContext of dependenciesDeployContexts) {
-        for (let policyDoc of deployContext.policies) {
-            policyStatementsToConsume.push(policyDoc);
-        }
-    }
-
-    //Let consuming service add its own policy if needed
-    for (let ownServicePolicyStatement of ownServicePolicyStatements) {
-        policyStatementsToConsume.push(ownServicePolicyStatement);
-    }
-
-    let roleName = `${ownServiceContext.appName}-${ownServiceContext.environmentName}-${ownServiceContext.serviceName}-${ownServiceContext.serviceType}`;
+exports.createCustomRole = function(trustedService, roleName, policyStatementsToConsume) {
     return iamCalls.createRoleIfNotExists(roleName, trustedService)
         .then(role => {
             if (policyStatementsToConsume.length > 0) { //Only add policies if there are any to consume
@@ -70,6 +55,26 @@ exports.createCustomRoleForService = function (trustedService, ownServicePolicyS
                 return iamCalls.getRole(roleName);
             }
         });
+}
+
+exports.createCustomRoleForService = function (trustedService, ownServicePolicyStatements, ownServiceContext, dependenciesDeployContexts) {
+    let policyStatementsToConsume = [];
+
+    //Add policies from dependencies that have them
+    for (let deployContext of dependenciesDeployContexts) {
+        for (let policyDoc of deployContext.policies) {
+            policyStatementsToConsume.push(policyDoc);
+        }
+    }
+
+    //Let consuming service add its own policy if needed
+    for (let ownServicePolicyStatement of ownServicePolicyStatements) {
+        policyStatementsToConsume.push(ownServicePolicyStatement);
+    }
+
+    let roleName = `${ownServiceContext.appName}-${ownServiceContext.environmentName}-${ownServiceContext.serviceName}-${ownServiceContext.serviceType}`;
+
+    return exports.createCustomRole(trustedService, roleName, policyStatementsToConsume);
 }
 
 exports.createSecurityGroupForService = function (sgName, addSshIngress) {

--- a/test/services/beanstalk/beanstalk-test.js
+++ b/test/services/beanstalk/beanstalk-test.js
@@ -122,6 +122,9 @@ describe('beanstalk deployer', function() {
             let createCustomRoleForServiceStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
                 RoleName: "FakeRole"
             }));
+            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({
+                RoleName: "FakeServiceRole"
+            }));
             let uploadDeployableArtifactToHandelBucketStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
                 Bucket: "FakeBucket",
                 Key: "FakeKey"
@@ -137,6 +140,7 @@ describe('beanstalk deployer', function() {
                 .then(deployContext => {
                     expect(uploadDeployableArtifactToHandelBucketStub.calledOnce).to.be.true;
                     expect(createCustomRoleForServiceStub.calledOnce).to.be.true;
+                    expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
                     expect(createStackStub.calledOnce).to.be.true;
                     expect(deployContext).to.be.instanceof(DeployContext);
@@ -146,6 +150,9 @@ describe('beanstalk deployer', function() {
         it('should update the service if it doesnt exist', function() {
             let createCustomRoleForServiceStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
                 RoleName: "FakeRole"
+            }));
+            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({
+                RoleName: "FakeServiceRole"
             }));
             let uploadDeployableArtifactToHandelBucketStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
                 Bucket: "FakeBucket",
@@ -162,6 +169,7 @@ describe('beanstalk deployer', function() {
                 .then(deployContext => {
                     expect(uploadDeployableArtifactToHandelBucketStub.calledOnce).to.be.true;
                     expect(createCustomRoleForServiceStub.calledOnce).to.be.true;
+                    expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
                     expect(updateStackStub.calledOnce).to.be.true;
                     expect(deployContext).to.be.instanceof(DeployContext);


### PR DESCRIPTION
This commit switches to use the ALB in Beanstalk. It supports
HTTP and HTTPS. If you use HTTPS then you must specify a certificate
from the ACM service by ID.