### PR TITLE
Move Role creation inside the CloudFormation for services.

### DIFF
--- a/lib/aws/cloudformation-calls.js
+++ b/lib/aws/cloudformation-calls.js
@@ -59,7 +59,7 @@ exports.createStack = function(stackName, templateBody, parameters) {
         StackName: stackName,
         OnFailure: 'DELETE',
         Parameters: parameters,
-        Capabilities: ["CAPABILITY_IAM"],
+        Capabilities: ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
         TemplateBody: templateBody,
         TimeoutInMinutes: 30
     };
@@ -78,7 +78,7 @@ exports.updateStack = function(stackName, templateBody, parameters) {
     var params = {
         StackName: stackName, 
         Parameters: parameters, 
-        Capabilities: ["CAPABILITY_IAM"],
+        Capabilities: ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
         TemplateBody:templateBody
     };
     winston.debug(`Updating CloudFormation stack ${stackName}`);

--- a/lib/services/apigateway/apigateway-proxy-template.yml
+++ b/lib/services/apigateway/apigateway-proxy-template.yml
@@ -1,9 +1,43 @@
 ---
 AWSTemplateFormatVersion: '2010-09-09'
 
-Description: API Gateway Lambda Proxy Template
+Description: Handel-created API Gateway application
 
 Resources:
+  LambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: {{apiName}}
+      Path: "/services/"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+              - "lambda.amazonaws.com"
+            Action:
+            - "sts:AssumeRole"
+  LambdaPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {{apiName}}
+      Roles:
+      - !Ref LambdaRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        {{#each policyStatements}}
+        - Effect: {{Effect}}
+          Action:
+          {{#each Action}}
+          - '{{{this}}}'
+          {{/each}}
+          Resource:
+          {{#each Resource}}
+          - '{{{this}}}'
+          {{/each}}
+        {{/each}}
   LambdaFunctionApiEventPermission:
     Type: AWS::Lambda::Permission
     Properties:
@@ -39,7 +73,7 @@ Resources:
           {{/each}}
       {{/if}}
       Handler: {{handlerFunction}}
-      Role: {{lambdaRoleArn}}
+      Role: !GetAtt LambdaRole.Arn
       Timeout: {{functionTimeout}}
       Runtime: {{lambdaRuntime}}
       {{#if tags}}

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -23,16 +23,11 @@ function uploadDeployableArtifactToS3(serviceContext) {
         });
 }
 
-function getPolicyStatementsForLambdaRole(serviceContext) {
-    return [{
-        "Effect": "Allow",
-        "Action": [
-            "logs:CreateLogGroup",
-            "logs:CreateLogStream",
-            "logs:PutLogEvents"
-        ],
-        "Resource": "*"
-    }].concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+function getPolicyStatementsForLambdaRole(serviceContext, dependenciesDeployContexts) {
+    let ownPolicyStatements = JSON.parse(util.readFileSync(`${__dirname}/lambda-role-statements.json`));
+    ownPolicyStatements = ownPolicyStatements.concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+
+    return deployersCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
 }
 
 function getEnvVarsForService(serviceContext, dependenciesDeployContexts) {
@@ -49,8 +44,10 @@ function getEnvVarsForService(serviceContext, dependenciesDeployContexts) {
     return returnEnvVars;
 }
 
-function getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependenciesDeployContexts, executionRole, s3ObjectInfo) {
+function getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ObjectInfo) {
     let serviceParams = ownServiceContext.params;
+
+    let policyStatements = getPolicyStatementsForLambdaRole(ownServiceContext, dependenciesDeployContexts);
 
     let provisionedMemory = serviceParams.provisioned_memory || "128";
     let functionTimeout = serviceParams.function_timeout || "3";
@@ -62,9 +59,9 @@ function getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependencie
         apiName: stackName,
         provisionedMemory,
         handlerFunction: serviceParams.handler_function,
-        lambdaRoleArn: executionRole.Arn,
         functionTimeout: functionTimeout.toString(),
-        lambdaRuntime: serviceParams.lambda_runtime
+        lambdaRuntime: serviceParams.lambda_runtime,
+        policyStatements
     }
 
     //Add tags if necessary
@@ -157,10 +154,7 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
 
     return uploadDeployableArtifactToS3(ownServiceContext)
         .then(s3ObjectInfo => {
-            return deployersCommon.createCustomRoleForService("lambda.amazonaws.com", getPolicyStatementsForLambdaRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
-                .then(role => {
-                    return getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependenciesDeployContexts, role, s3ObjectInfo);
-                })
+            return getCompiledApiGatewayTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ObjectInfo);
         })
         .then(compiledTemplate => {
             return cloudformationCalls.getStack(stackName)

--- a/lib/services/apigateway/lambda-role-statements.json
+++ b/lib/services/apigateway/lambda-role-statements.json
@@ -1,0 +1,13 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/beanstalk/beanstalk-instance-role-statements.json
+++ b/lib/services/beanstalk/beanstalk-instance-role-statements.json
@@ -19,7 +19,9 @@
             "xray:PutTelemetryRecords"
         ],
         "Effect": "Allow",
-        "Resource": "*"
+        "Resource": [
+            "*"
+        ]
     },
     {
         "Sid": "CloudWatchLogsAccess",
@@ -47,6 +49,8 @@
             "ecs:Submit*",
             "ecs:DescribeTasks"
         ],
-        "Resource": "*"
+        "Resource": [
+            "*"
+        ]
     }
 ]

--- a/lib/services/beanstalk/beanstalk-template.yml
+++ b/lib/services/beanstalk/beanstalk-template.yml
@@ -3,13 +3,47 @@ AWSTemplateFormatVersion: "2010-09-09"
 
 Description: Handel-created Beanstalk application
 
-Resources: 
+Resources:
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: {{applicationName}}
+      Path: "/services/"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement: 
+          - Effect: "Allow"
+            Principal: 
+              Service: 
+              - "ec2.amazonaws.com"
+            Action:
+            - "sts:AssumeRole"
+  Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {{applicationName}}
+      Roles:
+      - !Ref Role
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        {{#each policyStatements}}
+        - Effect: {{Effect}}
+          Action:
+          {{#each Action}}
+          - '{{{this}}}'
+          {{/each}}
+          Resource:
+          {{#each Resource}}
+          - '{{{this}}}'
+          {{/each}}
+        {{/each}}
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties: 
       Path: "/services/"
       Roles:
-      - {{beanstalkRoleName}}
+      - !Ref Role
   Application:
     Type: AWS::ElasticBeanstalk::Application
     Properties:

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -32,15 +32,18 @@ function getEnvVariablesToInject(serviceContext, dependenciesDeployContexts) {
 }
 
 
-function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContext, dependenciesDeployContexts, instanceRole, serviceRole, s3ArtifactInfo) {
+function getCompiledBeanstalkTemplate(stackName, preDeployContext, serviceContext, dependenciesDeployContexts, serviceRole, s3ArtifactInfo) {
     let serviceParams = serviceContext.params;
+
+    let policyStatements = getPolicyStatementsForInstanceRole(serviceContext, dependenciesDeployContexts)
+
     let handlebarsParams = {
         applicationName: stackName,
-        beanstalkRoleName: instanceRole.RoleName,
         applicationVersionBucket: s3ArtifactInfo.Bucket,
         applicationVersionKey: s3ArtifactInfo.Key,
         solutionStack: serviceParams.solution_stack,
-        optionSettings: []
+        optionSettings: [],
+        policyStatements
     };
 
     //Configure min and max size of ASG
@@ -120,12 +123,14 @@ function getDeployContext(serviceContext, cfStack) {
  * This returns the policy needed for Beanstalk to work in the web
  * tier, including Docker ECS multi-container support
  */
-function getPolicyStatementForInstanceRole(serviceContext) {
-    let policyStatements = JSON.parse(util.readFileSync(`${__dirname}/beanstalk-instance-role-statements.json`));
-    return policyStatements.concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+function getPolicyStatementsForInstanceRole(serviceContext, dependenciesDeployContexts) {
+    let ownPolicyStatements = JSON.parse(util.readFileSync(`${__dirname}/beanstalk-instance-role-statements.json`));
+    ownPolicyStatements = ownPolicyStatements.concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+
+    return deployersCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
 }
 
-function getPolicyStatementForServiceRole() {
+function getPolicyStatementsForServiceRole() {
     return JSON.parse(util.readFileSync(`${__dirname}/beanstalk-service-role-statements.json`));
 }
 
@@ -213,16 +218,13 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`Beanstalk - Executing Deploy on ${stackName}`);
 
-    return deployersCommon.createCustomRoleForService('ec2.amazonaws.com', getPolicyStatementForInstanceRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
-        .then(instanceRole => {
-            return deployersCommon.createCustomRole('elasticbeanstalk.amazonaws.com', 'HandelBeanstalkServiceRole', getPolicyStatementForServiceRole())
-                .then(serviceRole => {
-                    return uploadDeployableArtifactToS3(ownServiceContext)
-                        .then(s3ArtifactInfo => {
-                            return getCompiledBeanstalkTemplate(stackName, ownPreDeployContext, ownServiceContext, dependenciesDeployContexts, instanceRole, serviceRole, s3ArtifactInfo);
-                        });
-                });
-        })
+        return deployersCommon.createCustomRole('elasticbeanstalk.amazonaws.com', 'HandelBeanstalkServiceRole', getPolicyStatementsForServiceRole())
+            .then(serviceRole => {
+                return uploadDeployableArtifactToS3(ownServiceContext)
+                    .then(s3ArtifactInfo => {
+                        return getCompiledBeanstalkTemplate(stackName, ownPreDeployContext, ownServiceContext, dependenciesDeployContexts, serviceRole, s3ArtifactInfo);
+                    });
+            })
         .then(compiledBeanstalkTemplate => {
             return cloudFormationCalls.getStack(stackName)
                 .then(stack => {

--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -57,7 +57,7 @@ exports.createCustomRole = function(trustedService, roleName, policyStatementsTo
         });
 }
 
-exports.createCustomRoleForService = function (trustedService, ownServicePolicyStatements, ownServiceContext, dependenciesDeployContexts) {
+exports.getAllPolicyStatementsForServiceRole = function(ownServicePolicyStatements, dependenciesDeployContexts) {
     let policyStatementsToConsume = [];
 
     //Add policies from dependencies that have them
@@ -72,9 +72,7 @@ exports.createCustomRoleForService = function (trustedService, ownServicePolicyS
         policyStatementsToConsume.push(ownServicePolicyStatement);
     }
 
-    let roleName = `${ownServiceContext.appName}-${ownServiceContext.environmentName}-${ownServiceContext.serviceName}-${ownServiceContext.serviceType}`;
-
-    return exports.createCustomRole(trustedService, roleName, policyStatementsToConsume);
+    return policyStatementsToConsume;
 }
 
 exports.createSecurityGroupForService = function (sgName, addSshIngress) {
@@ -175,18 +173,21 @@ exports.getAppSecretsAccessPolicyStatements = function (serviceContext) {
             Action: [
                 "ssm:DescribeParameters"
             ],
-            Resource: "*"
+            Resource: [
+                "*"
+            ]
         },
         {
             Effect: "Allow",
             Action: [
                 "ssm:GetParameters"
             ],
-            Resource: `arn:aws:ssm:${accountConfig.region}:${accountConfig.account_id}:parameter/${serviceContext.appName}*`
+            Resource: [
+                `arn:aws:ssm:${accountConfig.region}:${accountConfig.account_id}:parameter/${serviceContext.appName}*`
+            ]
         }
     ]
 }
-
 
 exports.getResourceName = function (serviceContext) {
     return `${serviceContext.appName}-${serviceContext.environmentName}-${serviceContext.serviceName}-${serviceContext.serviceType}`;

--- a/lib/services/ecs/ecs-service-template.yml
+++ b/lib/services/ecs/ecs-service-template.yml
@@ -3,6 +3,40 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Handel-created ECS Cluster
 
 Resources:
+  TaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: {{clusterName}}
+      Path: "/services/"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement: 
+          - Effect: "Allow"
+            Principal: 
+              Service: 
+              - "ecs-tasks.amazonaws.com"
+            Action:
+            - "sts:AssumeRole"
+  TaskRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {{clusterName}}
+      Roles:
+      - !Ref TaskRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        {{#each policyStatements}}
+        - Effect: {{Effect}}
+          Action:
+          {{#each Action}}
+          - '{{{this}}}'
+          {{/each}}
+          Resource:
+          {{#each Resource}}
+          - '{{{this}}}'
+          {{/each}}
+        {{/each}}
   EcsIamRole:
     Type: AWS::IAM::Role
     Properties:
@@ -152,7 +186,7 @@ Resources:
     Type: AWS::ECS::TaskDefinition
     Properties:
       Family: {{clusterName}}
-      TaskRoleArn: {{taskRoleArn}}
+      TaskRoleArn: !GetAtt TaskRole.Arn
       NetworkMode: bridge
       {{#if volumes}}
       Volumes:

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -105,34 +105,28 @@ function getUserDataScript(clusterName, dependenciesDeployContexts) {
 
 function createEcsServiceRoleIfNotExists() {
     let roleName = 'HandelEcsServiceRole';
-    return iamCalls.createRoleIfNotExists(roleName, 'ecs.amazonaws.com')
+    let trustedService = 'ecs.amazonaws.com';
+    let policyStatementsToConsume = [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:Describe*",
+                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
+                "elasticloadbalancing:DeregisterTargets",
+                "elasticloadbalancing:Describe*",
+                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+                "elasticloadbalancing:RegisterTargets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+
+    return deployersCommon.createCustomRole(trustedService, roleName, policyStatementsToConsume)
         .then(role => {
-            let policyArn = `arn:aws:iam::${accountConfig.account_id}:policy/services/${roleName}`;
-            let policyDocument = {
-                "Version": "2012-10-17",
-                "Statement": [
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "ec2:AuthorizeSecurityGroupIngress",
-                            "ec2:Describe*",
-                            "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                            "elasticloadbalancing:DeregisterTargets",
-                            "elasticloadbalancing:Describe*",
-                            "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-                            "elasticloadbalancing:RegisterTargets"
-                        ],
-                        "Resource": "*"
-                    }
-                ]
-            }
-            return iamCalls.createPolicyIfNotExists(roleName, policyArn, policyDocument);
-        })
-        .then(policy => {
-            return iamCalls.attachPolicyToRole(policy.Arn, roleName);
-        })
-        .then(policyAttachment => {
-            return iamCalls.getRole(roleName);
+            return role;
         });
 }
 
@@ -151,8 +145,17 @@ function getDependenciesDeployContextMountPoints(dependenciesDeployContexts) {
     return mountPoints;
 }
 
-function getCompiledEcsTemplate(clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, taskRole, ecsServiceRole) {
+function getTaskRoleStatements(serviceContext, dependenciesDeployContexts) {
+    let ownPolicyStatements = deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext);
+
+    return deployersCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
+}
+
+function getCompiledEcsTemplate(clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole) {
     let serviceParams = ownServiceContext.params;
+
+    let taskRoleStatements = getTaskRoleStatements(ownServiceContext, dependenciesDeployContexts);
+
     let minContainers = serviceParams.min_containers || 1;
     let maxContainers = serviceParams.max_containers || 1;
     let instanceType = serviceParams.instance_type || "t2.micro";
@@ -179,20 +182,20 @@ function getCompiledEcsTemplate(clusterName, ownServiceContext, ownPreDeployCont
         minimumHealthyPercentDeployment: "0", //TODO - Change later
         publicSubnetIds: accountConfig.public_subnets,
         containerName: clusterName,
-        dockerImage: imageName, 
+        dockerImage: imageName,
         vpcId: accountConfig.vpc,
         ecsServiceRoleArn: ecsServiceRole.Arn,
-        taskRoleArn: taskRole.Arn,
+        policyStatements: taskRoleStatements,
         maxMb: maxMb.toString(),
         cpuUnits: cpuUnits.toString(),
         deployVersion: ownServiceContext.deployVersion.toString()
     };
 
     //Add port mappings if routing is specified
-    if(serviceParams.routing) {
+    if (serviceParams.routing) {
         //Wire up first port to Load Balancer
         handlebarsParams.containerPort = serviceParams.port_mappings[0].toString();
-        
+
         //Add port mappings to container
         for (let portToMap of serviceParams['port_mappings']) {
             handlebarsParams.portMappings.push(portToMap);
@@ -247,7 +250,7 @@ function getCompiledEcsTemplate(clusterName, ownServiceContext, ownPreDeployCont
     }
 
     //Add tags (if specified)
-    if(serviceParams.tags) {
+    if (serviceParams.tags) {
         handlebarsParams.tags = serviceParams.tags
     }
 
@@ -273,7 +276,7 @@ function getShortenedClusterName(serviceContext) {
 exports.check = function (serviceContext) {
     let errors = [];
     let params = serviceContext.params;
-    if(params.routing) {
+    if (params.routing) {
         if (!params.port_mappings || params.port_mappings.length === 0) {
             errors.push("ECS - 'port_mappings' parameter is required when you specify the 'routing' element");
         }
@@ -345,13 +348,10 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let clusterName = getShortenedClusterName(ownServiceContext);
     return getUserDataScript(clusterName, dependenciesDeployContexts)
         .then(userDataScript => {
-            return deployersCommon.createCustomRoleForService("ecs-tasks.amazonaws.com", deployersCommon.getAppSecretsAccessPolicyStatements(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
-                .then(taskRole => {
-                    return createEcsServiceRoleIfNotExists()
-                        .then(ecsServiceRole => {
-                            return getCompiledEcsTemplate(clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, taskRole, ecsServiceRole)
-                        })
-                })
+            return createEcsServiceRoleIfNotExists()
+                .then(ecsServiceRole => {
+                    return getCompiledEcsTemplate(clusterName, ownServiceContext, ownPreDeployContext, dependenciesDeployContexts, userDataScript, ecsServiceRole)
+                });
         })
         .then(compiledTemplate => {
             return cloudformationCalls.getStack(stackName)

--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -4,12 +4,11 @@ const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const ConsumeEventsContext = require('../../datatypes/consume-events-context');
-const accountConfig = require('../../util/account-config')().getAccountConfig();
+const util = require('../../util/util');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const lambdaCalls = require('../../aws/lambda-calls');
 const deployersCommon = require('../deployers-common');
 const uuid = require('uuid');
-
 
 function getEnvVariablesToInject(serviceContext, dependenciesDeployContexts) {
     let serviceParams = serviceContext.params;
@@ -23,19 +22,22 @@ function getEnvVariablesToInject(serviceContext, dependenciesDeployContexts) {
 }
 
 
-function getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, customRole, s3ArtifactInfo) {
+function getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ArtifactInfo) {
     let serviceParams = ownServiceContext.params;
+    
+    let policyStatements = getPolicyStatementsForLambdaRole(ownServiceContext, dependenciesDeployContexts);
+    
     let memorySize = serviceParams.memory || 128;
     let timeout = serviceParams.timeout || 3;
     let handlebarsParams = {
         functionName: stackName,
         s3ArtifactBucket: s3ArtifactInfo.Bucket,
         s3ArtifactKey: s3ArtifactInfo.Key,
-        executionRoleArn: customRole.Arn,
         handler: serviceParams.handler,
         runtime: serviceParams.runtime,
         memorySize: memorySize,
-        timeout: timeout
+        timeout: timeout,
+        policyStatements
     };
 
     //Inject environment variables (if any)
@@ -69,18 +71,11 @@ function uploadDeployableArtifactToS3(serviceContext) {
         });
 }
 
-function getPolicyStatementsForLambdaRole(serviceContext) {
-    return [
-        {
-            "Action": [
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents"
-            ],
-            "Resource": "arn:aws:logs:*:*:*",
-            "Effect": "Allow"
-        }
-    ].concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+function getPolicyStatementsForLambdaRole(serviceContext, dependenciesDeployContexts) {
+    let ownPolicyStatements = JSON.parse(util.readFileSync(`${__dirname}/lambda-role-statements.json`));
+    ownPolicyStatements = ownPolicyStatements.concat(deployersCommon.getAppSecretsAccessPolicyStatements(serviceContext));
+
+    return deployersCommon.getAllPolicyStatementsForServiceRole(ownPolicyStatements, dependenciesDeployContexts);
 }
 
 
@@ -159,12 +154,9 @@ exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesD
     let stackName = deployersCommon.getResourceName(ownServiceContext);
     winston.info(`Lambda - Executing Deploy on ${stackName}`);
 
-    return deployersCommon.createCustomRoleForService('lambda.amazonaws.com', getPolicyStatementsForLambdaRole(ownServiceContext), ownServiceContext, dependenciesDeployContexts)
-        .then(customRole => {
-            return uploadDeployableArtifactToS3(ownServiceContext)
-                .then(s3ArtifactInfo => {
-                    return getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, customRole, s3ArtifactInfo);
-                });
+    return uploadDeployableArtifactToS3(ownServiceContext)
+        .then(s3ArtifactInfo => {
+            return getCompiledLambdaTemplate(stackName, ownServiceContext, dependenciesDeployContexts, s3ArtifactInfo);
         })
         .then(compiledLambdaTemplate => {
             return cloudFormationCalls.getStack(stackName)

--- a/lib/services/lambda/lambda-role-statements.json
+++ b/lib/services/lambda/lambda-role-statements.json
@@ -1,0 +1,13 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "logs:CreateLogGroup",
+            "logs:CreateLogStream",
+            "logs:PutLogEvents"
+        ],
+        "Resource": [
+            "arn:aws:logs:*:*:*"
+        ]
+    }
+]

--- a/lib/services/lambda/lambda-template.yml
+++ b/lib/services/lambda/lambda-template.yml
@@ -3,6 +3,40 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: Handel-created Lambda function
 
 Resources:
+  Role:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: {{functionName}}
+      Path: "/services/"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+              - "lambda.amazonaws.com"
+            Action:
+            - "sts:AssumeRole"
+  Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: {{functionName}}
+      Roles:
+      - !Ref Role
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        {{#each policyStatements}}
+        - Effect: {{Effect}}
+          Action:
+          {{#each Action}}
+          - '{{{this}}}'
+          {{/each}}
+          Resource:
+          {{#each Resource}}
+          - '{{{this}}}'
+          {{/each}}
+        {{/each}}
   Function:
     Type: AWS::Lambda::Function
     Properties: 
@@ -20,7 +54,7 @@ Resources:
       FunctionName: {{functionName}}
       Handler: {{handler}}
       MemorySize: {{memorySize}}
-      Role: {{executionRoleArn}}
+      Role: !GetAtt Role.Arn
       Runtime: {{runtime}}
       Timeout: {{timeout}}
       {{#if tags}}

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -32,7 +32,9 @@ function getDeployContext(serviceContext, cfStack) {
         "Action": [
             "s3:ListBucket"
         ],
-        "Resource": [`arn:aws:s3:::${bucketName}`]
+        "Resource": [
+            `arn:aws:s3:::${bucketName}`
+        ]
     })
     deployContext.policies.push({
         "Effect": "Allow",
@@ -41,7 +43,9 @@ function getDeployContext(serviceContext, cfStack) {
             "s3:GetObject",
             "s3:DeleteObject"
         ],
-        "Resource": [`arn:aws:s3:::${bucketName}/*`]
+        "Resource": [
+            `arn:aws:s3:::${bucketName}/*`
+        ]
     });
 
     return deployContext;

--- a/lib/util/util.js
+++ b/lib/util/util.js
@@ -3,8 +3,6 @@ const path = require('path');
 const yaml = require('js-yaml');
 const archiver = require('archiver');
 const winston = require('winston');
-const ServiceContext = require('../datatypes/service-context');
-const request = require('request');
 
 exports.readFileSync = function(filePath) {
     try {

--- a/test/services/apigateway/apigateway-test.js
+++ b/test/services/apigateway/apigateway-test.js
@@ -114,10 +114,6 @@ describe('apigateway deployer', function() {
                 Bucket: bucketName,
                 Key: bucketKey
             }));
-            let roleArn = "FakeArn";
-            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
-                Arn: roleArn
-            }));
             let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve(null));
             let createStackStub = sandbox.stub(cloudFormationCalls, 'createStack').returns(Promise.resolve({
                 Outputs: [{
@@ -130,7 +126,6 @@ describe('apigateway deployer', function() {
                 .then(deployContext => {
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(uploadDeployableArtifactToHandelBucketStub.calledOnce).to.be.true;
-                    expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
                     expect(createStackStub.calledOnce).to.be.true;
                 });
@@ -152,10 +147,6 @@ describe('apigateway deployer', function() {
                 Bucket: bucketName,
                 Key: bucketKey
             }));
-            let roleArn = "FakeArn";
-            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
-                Arn: roleArn
-            }));
             let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({}));
             let updateStackStub = sandbox.stub(cloudFormationCalls, 'updateStack').returns(Promise.resolve({
                 Outputs: [{
@@ -168,7 +159,6 @@ describe('apigateway deployer', function() {
                 .then(deployContext => {
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(uploadDeployableArtifactToHandelBucketStub.calledOnce).to.be.true;
-                    expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
                     expect(updateStackStub.calledOnce).to.be.true;
                 });

--- a/test/services/beanstalk/beanstalk-test.js
+++ b/test/services/beanstalk/beanstalk-test.js
@@ -82,9 +82,6 @@ describe('beanstalk deployer', function() {
         }
 
         it('should create the service if it doesnt exist', function() {
-            let createCustomRoleForServiceStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
-                RoleName: "FakeRole"
-            }));
             let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({
                 RoleName: "FakeServiceRole"
             }));
@@ -102,7 +99,6 @@ describe('beanstalk deployer', function() {
             return beanstalk.deploy(ownServiceContext, ownPreDeployContext, [])
                 .then(deployContext => {
                     expect(uploadDeployableArtifactToHandelBucketStub.calledOnce).to.be.true;
-                    expect(createCustomRoleForServiceStub.calledOnce).to.be.true;
                     expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
                     expect(createStackStub.calledOnce).to.be.true;
@@ -111,9 +107,6 @@ describe('beanstalk deployer', function() {
         });
 
         it('should update the service if it doesnt exist', function() {
-            let createCustomRoleForServiceStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
-                RoleName: "FakeRole"
-            }));
             let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({
                 RoleName: "FakeServiceRole"
             }));
@@ -131,7 +124,6 @@ describe('beanstalk deployer', function() {
             return beanstalk.deploy(ownServiceContext, ownPreDeployContext, [])
                 .then(deployContext => {
                     expect(uploadDeployableArtifactToHandelBucketStub.calledOnce).to.be.true;
-                    expect(createCustomRoleForServiceStub.calledOnce).to.be.true;
                     expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
                     expect(updateStackStub.calledOnce).to.be.true;

--- a/test/services/ecs/ecs-test.js
+++ b/test/services/ecs/ecs-test.js
@@ -166,18 +166,7 @@ describe('ecs deployer', function() {
             let dependenciesDeployContexts = getDependenciesDeployContextsForDeploy(appName, envName, deployVersion);            
 
             //Stub out AWS calls
-            let fakeArn = "FakeArn";
-            let createCustomRoleForServiceStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
-                Arn: "FakeRoleArn" 
-            }));
-            let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve({}));
-            let createPolicyStub = sandbox.stub(iamCalls, 'createPolicyIfNotExists').returns(Promise.resolve({
-                Arn: fakeArn
-            }))
-            let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
-            let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve({
-                Arn: fakeArn
-            }))
+            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({}));
             let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve(null));
             let createStackStub = sandbox.stub(cloudformationCalls, 'createStack').returns(Promise.resolve({}));
 
@@ -185,8 +174,8 @@ describe('ecs deployer', function() {
             return ecs.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
                 .then(deployContext => {
                     expect(deployContext).to.be.instanceof(DeployContext);
-                    expect(createCustomRoleForServiceStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
+                    expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(createStackStub.calledOnce).to.be.true;
                 });
         });
@@ -206,18 +195,8 @@ describe('ecs deployer', function() {
             let dependenciesDeployContexts = getDependenciesDeployContextsForDeploy(appName, envName, deployVersion);            
 
             //Stub out AWS calls
-            let createCustomRoleForServiceStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
-                Arn: "FakeRoleArn" 
-            }));
             let fakeArn = "FakeArn";
-            let createRoleStub = sandbox.stub(iamCalls, 'createRoleIfNotExists').returns(Promise.resolve({}));
-            let createPolicyStub = sandbox.stub(iamCalls, 'createPolicyIfNotExists').returns(Promise.resolve({
-                Arn: fakeArn
-            }))
-            let attachPolicyStub = sandbox.stub(iamCalls, 'attachPolicyToRole').returns(Promise.resolve({}));
-            let getRoleStub = sandbox.stub(iamCalls, 'getRole').returns(Promise.resolve({
-                Arn: fakeArn
-            }))
+            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRole').returns(Promise.resolve({}));
             let getStackStub = sandbox.stub(cloudformationCalls, 'getStack').returns(Promise.resolve({}));
             let updateStackStub = sandbox.stub(cloudformationCalls, 'updateStack').returns(Promise.resolve({}));
 
@@ -225,8 +204,8 @@ describe('ecs deployer', function() {
             return ecs.deploy(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts)
                 .then(deployContext => {
                     expect(deployContext).to.be.instanceof(DeployContext);
-                    expect(createCustomRoleForServiceStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
+                    expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(updateStackStub.calledOnce).to.be.true;
             });
         });

--- a/test/services/lambda/lambda-test.js
+++ b/test/services/lambda/lambda-test.js
@@ -119,9 +119,6 @@ describe('lambda deployer', function() {
 
         
         it('should create the service when it doesnt already exist', function() {
-            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
-                Arn: "FakeArn"
-            }));
             let uploadArtifactStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
                 Key: "FakeKey",
                 Bucket: "FakeBucket"
@@ -151,7 +148,6 @@ describe('lambda deployer', function() {
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.eventOutputs.lambdaArn).to.equal(functionArn);
                     expect(deployContext.eventOutputs.lambdaName).to.equal(functionName);
-                    expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(uploadArtifactStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
                     expect(createStackStub.calledOnce).to.be.true;
@@ -159,9 +155,6 @@ describe('lambda deployer', function() {
         });
 
         it('should update the service when it already exists', function() {
-            let createCustomRoleStub = sandbox.stub(deployersCommon, 'createCustomRoleForService').returns(Promise.resolve({
-                Arn: "FakeArn"
-            }));
             let uploadArtifactStub = sandbox.stub(deployersCommon, 'uploadDeployableArtifactToHandelBucket').returns(Promise.resolve({
                 Key: "FakeKey",
                 Bucket: "FakeBucket"
@@ -191,7 +184,6 @@ describe('lambda deployer', function() {
                     expect(deployContext).to.be.instanceof(DeployContext);
                     expect(deployContext.eventOutputs.lambdaArn).to.equal(functionArn);
                     expect(deployContext.eventOutputs.lambdaName).to.equal(functionName);
-                    expect(createCustomRoleStub.calledOnce).to.be.true;
                     expect(uploadArtifactStub.calledOnce).to.be.true;
                     expect(getStackStub.calledOnce).to.be.true;
                     expect(updateStackStub.calledOnce).to.be.true;


### PR DESCRIPTION
Previously we were creating roles outside the CloudFormation, but
now we have more dynamic ways of creating the CF, so this is
feasible to do inside the CF now.

Resolves #121 