### PR TITLE
Create security groups inside CloudFormation

### DIFF
--- a/lib/aws/ec2-calls.js
+++ b/lib/aws/ec2-calls.js
@@ -3,76 +3,6 @@ const winston = require('winston');
 
 
 /**
- * Creates the service group with the given name if it doesn't exist already
- * 
- * The group created here does not have any ingress rules at first. Those must be
- * manually added
- * 
- * @param {String} groupName - The name of the security group that will be created
- * @param {String} vpcId - The ID of the VPC in which to create the security group
- * @returns {Promise.<SecurityGroup>} - A Promise of the Security group
- */
-exports.createSecurityGroupIfNotExists = function(groupName, vpcId) {
-    return exports.getSecurityGroup(groupName, vpcId)
-        .then(securityGroup => {
-            if(securityGroup) {
-                return securityGroup;
-            }
-            else {
-                return exports.createSecurityGroup(groupName, vpcId);
-            }
-        });
-}
-
-
-/**
- * Creates the service group with the given name if it doesn't exist already
- * 
- * The group created here does not have any ingress rules at first. Those must be
- * manually added
- * 
- * @param {String} groupName - The name of the security group that will be created
- * @param {String} vpcId - The ID of the VPC in which to create the security group
- * @returns {Promise.<SecurityGroup>} - A Promise of the Security group
- */
-exports.createSecurityGroup = function(groupName, vpcId) {
-    const ec2 = new AWS.EC2({
-        apiVersion: '2016-11-15'
-    });
-    let createSgParams = {
-        Description: groupName,
-        GroupName: groupName,
-        VpcId: vpcId
-    }
-    winston.debug(`Creating security group ${groupName} in VPC ${vpcId}`);
-    return ec2.createSecurityGroup(createSgParams).promise()
-        .then(createResult => {
-            winston.debug(`Created security group ${groupName} in VPC ${vpcId}`);
-            return exports.getSecurityGroup(groupName, vpcId)
-                .then(securityGroup => {
-                    if(securityGroup) {
-                        return securityGroup;
-                    }
-                    else {
-                        throw new Error(`Couldn't find created security group ${groupName}`);
-                    }
-                });
-        })
-        .then(securityGroup => {
-            return exports.tagResource(securityGroup['GroupId'], [
-                {
-                    Key: "Name",
-                    Value: securityGroup['GroupName']
-                }
-            ])
-            .then(tagResult => {
-                return securityGroup;
-            })
-        });
-}
-
-
-/**
  * Returns the information about the requested security group if it exists.
  * 
  * @param {String} groupName - The name of the security group to search for
@@ -137,22 +67,6 @@ exports.getSecurityGroupById = function(groupId, vpcId) {
                 return null;
             }
         });
-}
-
-
-//TODO - Document this
-exports.tagResource = function(resourceId, tags) {
-    const ec2 = new AWS.EC2({
-        apiVersion: '2016-11-15'
-    });
-    var tagParams = {
-        Resources: [
-            resourceId
-        ], 
-        Tags: tags
-    };
-    winston.debug(`Tagging EC2 resource ${resourceId}`);
-    return ec2.createTags(tagParams).promise();
 }
 
 exports.ingressRuleExists = function(securityGroup, startPort, endPort, protocol, sourceSg) {

--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -1,9 +1,11 @@
 const iamCalls = require('../aws/iam-calls');
 const s3Calls = require('../aws/s3-calls');
 const ec2Calls = require('../aws/ec2-calls');
+const cloudformationCalls = require('../aws/cloudformation-calls');
 const accountConfig = require('../util/account-config')().getAccountConfig();
 const fs = require('fs');
 const util = require('../util/util');
+const handlebarsUtils = require('../util/handlebars-utils');
 const os = require('os');
 
 /**
@@ -75,23 +77,31 @@ exports.getAllPolicyStatementsForServiceRole = function(ownServicePolicyStatemen
     return policyStatementsToConsume;
 }
 
-exports.createSecurityGroupForService = function (sgName, addSshIngress) {
-    return ec2Calls.createSecurityGroupIfNotExists(sgName, accountConfig['vpc'])
-        .then(securityGroup => {
-            //Add ingress from self
-            return ec2Calls.addIngressRuleToSgIfNotExists(securityGroup, securityGroup, 'tcp', 0, 65535, accountConfig['vpc']);
+exports.createSecurityGroupForService = function (stackName, addSshIngress) {
+    let sgName = `${stackName}-sg`;
+    let handlebarsParams = {
+        groupName: sgName,
+        vpcId: accountConfig.vpc
+    }
+    if(addSshIngress) {
+        handlebarsParams.sshSg = accountConfig.ssh_bastion_sg
+    }
+
+    return handlebarsUtils.compileTemplate(`${__dirname}/ec2-sg-template.yml`, handlebarsParams)
+        .then(compiledTemplate => {
+            return cloudformationCalls.getStack(sgName)
+                .then(stack => {
+                    if(!stack) {
+                        return cloudformationCalls.createStack(sgName, compiledTemplate, []);
+                    }
+                    else {
+                        return cloudformationCalls.updateStack(sgName, compiledTemplate, []);
+                    }
+                });
         })
-        .then(securityGroup => {
-            if (addSshIngress) {
-                //Add ingress from SSH bastion
-                return ec2Calls.getSecurityGroupById(accountConfig.ssh_bastion_sg, accountConfig.vpc)
-                    .then(sshBastionSg => {
-                        return ec2Calls.addIngressRuleToSgIfNotExists(sshBastionSg, securityGroup, 'tcp', 22, 22, accountConfig['vpc']);
-                    });
-            }
-            else {
-                return securityGroup;
-            }
+        .then(deployedStack => {
+            let groupId = cloudformationCalls.getOutput('GroupId', deployedStack)
+            return ec2Calls.getSecurityGroupById(groupId, accountConfig.vpc);
         });
 }
 

--- a/lib/services/ec2-sg-template.yml
+++ b/lib/services/ec2-sg-template.yml
@@ -1,0 +1,37 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Handel-created security group
+
+Resources:
+  SecurityGroup:
+    Type: "AWS::EC2::SecurityGroup"
+    Properties: 
+      GroupName: {{groupName}}
+      GroupDescription: {{groupName}}
+      Tags:
+        - Key: Name
+          Value: {{groupName}}
+      VpcId: {{vpcId}}
+  {{#if sshSg}}
+  SshIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      FromPort: 22
+      GroupId:  !GetAtt SecurityGroup.GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId: {{sshSg}}
+      ToPort: 22
+  {{/if}}
+  SelfIngress:
+    Type: "AWS::EC2::SecurityGroupIngress"
+    Properties:
+      FromPort: 0
+      GroupId:  !GetAtt SecurityGroup.GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId: !GetAtt SecurityGroup.GroupId
+      ToPort: 65535
+
+Outputs:
+  GroupId:
+    Description: The ID of the created security group
+    Value: !GetAtt SecurityGroup.GroupId


### PR DESCRIPTION
This change puts security group creation inside a CloudFormation
template. This is to allow people to easily see at a glance all
the resources for their app by looking at CloudFormation. If they
want to delete an environment, all they need to do is delete the
templates for that env and all resources will go away.

Resolves #120 