### PR TITLE
Add delete lifecyle to Handel

### DIFF
--- a/bin/handel
+++ b/bin/handel
@@ -2,9 +2,7 @@
 const handel = require('../lib/handel');
 const minimist = require('minimist');
 const fs = require('fs');
-const path = require('path');
 const winston = require('winston');
-const util = require('../lib/util/util');
 const yaml = require('js-yaml');
 const cli = require('../lib/cli');
 
@@ -39,13 +37,30 @@ Errors:
     printAndExit(usageMsg);
 }
 
-function deployAction(handelFile, argv) {
-    if(argv.d) {
+function printDeleteUsage(errors) {
+    let usageMsg = `Usage: handel delete -c <accountConfig> -e <envsToDelete>
+
+Options:
+-c [required] -- Path to account config or base64 encoded JSON string of config
+-e [required] -- A comma-separated list of environments from your handel file to deploy
+-d -- If this flag is set, verbose debug output will be enabled
+
+Errors: 
+  ${errors.join('\n  ')}`;
+    printAndExit(usageMsg);
+}
+
+function setLogLevel(argv) {
+    if (argv.d) {
         winston.level = 'debug';
     }
     else {
         winston.level = 'info';
     }
+}
+
+function deployAction(handelFile, argv) {
+    setLogLevel(argv);
     let accountConfig = cli.loadAccountConfig(argv.c);
     let deployVersion = argv.v;
     let environmentsToDeploy = argv.e.split(',');
@@ -78,8 +93,34 @@ function checkAction(handelFile) {
     handel.check(handelFile);
 }
 
-function deleteAction(argv) {
-    throw new Error("DELETE ACTION IS NOT IMPLEMENTED YET!");
+function deleteAction(handelFile, argv) {
+    setLogLevel(argv);
+    let accountConfig = cli.loadAccountConfig(argv.c);
+    let environmentToDelete = argv.e;
+    cli.confirmDelete(environmentToDelete)
+        .then(confirmDelete => {
+            if (confirmDelete) {
+                handel.delete(accountConfig, handelFile, environmentToDelete)
+                    .then(envDeleteResult => {
+                        if (envDeleteResult.status !== 'success') {
+                            winston.warn(`Error while deleting environment: ${envDeleteResult.message}`);
+                            winston.warn(envDeleteResult.error);
+                            winston.warn("Finished deletion with errors");
+                            process.exit(1);
+                        }
+                        else {
+                            winston.info("Finished deleting everything successfully");
+                        }
+                    })
+                    .catch(err => {
+                        winston.warn(err);
+                        process.exit(1);
+                    })
+            }
+            else {
+                winston.info("You did not type 'yes' to confirm deletion. Will not delete environment.");
+            }
+        });
 }
 
 function loadHandelFile() {
@@ -88,10 +129,10 @@ function loadHandelFile() {
         return handelFile;
     }
     catch (e) {
-        if(e.code === 'ENOENT') {
+        if (e.code === 'ENOENT') {
             printAndExit(`No 'handel.yml' file found in this directory. You must run Handel in the directory containing the Handel file.`);
         }
-        else if(e.name === 'YAMLException') {
+        else if (e.name === 'YAMLException') {
             printAndExit(`Malformed 'handel.yml' file. Make sure your Handel file is a properly formatted YAML file. You're probably missing a space or two somewhere`);
         }
         else {
@@ -103,9 +144,10 @@ function loadHandelFile() {
 let handelFile = loadHandelFile();
 let deployPhase = process.argv[2];
 let argv = minimist(process.argv.slice(2));
+let errors = [];
 switch (deployPhase) {
     case "deploy":
-        let errors = cli.validateDeployArgs(argv, handelFile);
+        errors = cli.validateDeployArgs(argv, handelFile);
         if (errors.length > 0) {
             printDeployUsage(errors);
         }
@@ -117,8 +159,13 @@ switch (deployPhase) {
         checkAction(handelFile);
         break;
     case "delete":
-        cli.validateDeleteArgs(argv);
-        deleteAction(handelFile, argv);
+        errors = cli.validateDeleteArgs(argv, handelFile);
+        if (errors.length > 0) {
+            printDeleteUsage(errors);
+        }
+        else {
+            deleteAction(handelFile, argv);
+        }
         break;
     default:
         printGeneralUsage();

--- a/docs/handel-basics/deleting-an-environment.rst
+++ b/docs/handel-basics/deleting-an-environment.rst
@@ -1,0 +1,44 @@
+.. _deleting-an-environment:
+
+Deleting an Environment
+=======================
+Once you've created an application using Handel, you may decide to delete one or more of your environments. This document tells how to delete your environments.
+
+.. DANGER::
+
+    If you delete an environment, it will delete all data in your environment! 
+    
+    Please review the data in an environment carefully before deleting it. You are responsible fo
+    
+To delete an environment, do the following:
+
+Execute Handel's delete lifecycle, passing in the environment you want to delete:
+
+.. code-block:: bash
+
+    # Note that you need to also pass in the account config file
+    handel delete -c ~/projects/byu/handel-account-configs/prd-swat-oit-byu.yml -e dev
+
+When you execute that command, Handel will show you a big warning message like the following:
+
+.. code-block:: none
+
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    WARNING: YOU ARE ABOUT TO DELETE YOUR HANDEL ENVIRONMENT 'dev'!
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    If you choose to delete this environment, you will lose all data stored in the environment!
+
+    In particular, you will lose all data in the following:
+
+    * Databases
+    * Caches
+    * S3 Buckets
+    * EFS Mounts
+
+    PLEASE REVIEW this environment thoroughly, as you are responsible for all data loss associated with an accidental deletion.
+    PLEASE BACKUP your data sources before deleting this environment just to be safe.
+
+    ? Enter 'yes' to delete your environment. Handel will refuse to delete the environment with any other answer:
+
+Type 'yes' at the prompt to delete the environment. Handel will then proceed to delete the environment.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,6 +22,7 @@ Handel is a library that orchestrates your AWS deployments so you don't have to
    handel-basics/consuming-service-dependencies
    handel-basics/service-events
    handel-basics/accessing-secrets
+   handel-basics/deleting-an-environment
 
 .. _supported-services:
 

--- a/lib/aws/cloudformation-calls.js
+++ b/lib/aws/cloudformation-calls.js
@@ -7,7 +7,7 @@ const AWS = require('aws-sdk');
  * @param {String} stackName - The name of the stack to get
  * @returns - The CloudFormation Stack, or null if it doesnt exist
  */
-exports.getStack = function(stackName) {
+exports.getStack = function (stackName) {
     const cloudformation = new AWS.CloudFormation({
         apiVersion: '2010-05-15'
     });
@@ -21,7 +21,7 @@ exports.getStack = function(stackName) {
             return describeResult.Stacks[0];
         })
         .catch(err => {
-            if(err.code === "ValidationError") { //Stack does not exist
+            if (err.code === "ValidationError") { //Stack does not exist
                 winston.debug(`CloudFormation stack ${stackName} not found`);
                 return null;
             }
@@ -36,7 +36,7 @@ exports.getStack = function(stackName) {
  * @param {String} stackState - The state to wait for
  * @returns
  */
-exports.waitForStack = function(stackName, stackState) {
+exports.waitForStack = function (stackName, stackState) {
     winston.debug(`Waiting for ${stackName} to be in ${stackState}`);
     const cloudformation = new AWS.CloudFormation({
         apiVersion: '2010-05-15'
@@ -51,7 +51,7 @@ exports.waitForStack = function(stackName, stackState) {
         });
 }
 
-exports.createStack = function(stackName, templateBody, parameters) {
+exports.createStack = function (stackName, templateBody, parameters) {
     const cloudformation = new AWS.CloudFormation({
         apiVersion: '2010-05-15'
     });
@@ -67,28 +67,28 @@ exports.createStack = function(stackName, templateBody, parameters) {
     return cloudformation.createStack(params).promise()
         .then(createResult => {
             winston.debug(`Created CloudFormation stack ${stackName}`);
-            return exports.waitForStack(stackName, 'stackCreateComplete')   
+            return exports.waitForStack(stackName, 'stackCreateComplete')
         });
 }
 
-exports.updateStack = function(stackName, templateBody, parameters) {
+exports.updateStack = function (stackName, templateBody, parameters) {
     const cloudformation = new AWS.CloudFormation({
         apiVersion: '2010-05-15'
     });
     var params = {
-        StackName: stackName, 
-        Parameters: parameters, 
+        StackName: stackName,
+        Parameters: parameters,
         Capabilities: ["CAPABILITY_IAM", "CAPABILITY_NAMED_IAM"],
-        TemplateBody:templateBody
+        TemplateBody: templateBody
     };
     winston.debug(`Updating CloudFormation stack ${stackName}`);
     return cloudformation.updateStack(params).promise()
         .then(createResult => {
             winston.debug(`Updated CloudFormation stack ${stackName}`);
-            return exports.waitForStack(stackName, 'stackUpdateComplete')   
+            return exports.waitForStack(stackName, 'stackUpdateComplete')
         })
         .catch(err => {
-            if(err.message.includes('No updates are to be performed')) {
+            if (err.message.includes('No updates are to be performed')) {
                 winston.debug(`No stack updates were required for stack ${stackName}`);
                 return exports.getStack(stackName);
             }
@@ -96,10 +96,30 @@ exports.updateStack = function(stackName, templateBody, parameters) {
         })
 }
 
-exports.getCfStyleStackParameters = function(parametersObj) {
+exports.deleteStack = function (stackName) {
+    const cloudformation = new AWS.CloudFormation({
+        apiVersion: '2010-05-15'
+    });
+    var deleteParams = {
+        StackName: stackName
+    };
+    winston.debug(`Deleting CloudFormation stack ${stackName}`);
+    return cloudformation.deleteStack(deleteParams).promise()
+        .then(deleteResult => {
+            var waitParams = {
+                StackName: stackName
+            };
+            return cloudformation.waitFor('stackDeleteComplete', waitParams).promise()
+                .then(waitResponse => {
+                    return true;
+                });
+        });
+}
+
+exports.getCfStyleStackParameters = function (parametersObj) {
     let stackParameters = [];
 
-    for(let key in parametersObj) {
+    for (let key in parametersObj) {
         stackParameters.push({
             ParameterKey: key,
             ParameterValue: parametersObj[key],
@@ -114,9 +134,9 @@ exports.getCfStyleStackParameters = function(parametersObj) {
  * Given a CloudFormation stack, get the output for the given key
  * Returns null if key is not found
  */
-exports.getOutput = function(outputKey, cfStack) {
-    for(let output of cfStack.Outputs) {
-        if(output.OutputKey === outputKey) {
+exports.getOutput = function (outputKey, cfStack) {
+    for (let output of cfStack.Outputs) {
+        if (output.OutputKey === outputKey) {
             return output.OutputValue;
         }
     }

--- a/lib/aws/cloudwatch-events-calls.js
+++ b/lib/aws/cloudwatch-events-calls.js
@@ -21,7 +21,7 @@ exports.addTarget = function (ruleName, targetArn, targetId, input) {
             }
         ]
     };
-    if(input) { //Not all targets will want to override input, but some like scheduled Lambda will.
+    if (input) { //Not all targets will want to override input, but some like scheduled Lambda will.
         putParams.Targets[0].Input = input;
     }
     winston.debug(`Adding target '${targetArn}' to rule '${ruleName}'`)
@@ -29,5 +29,68 @@ exports.addTarget = function (ruleName, targetArn, targetId, input) {
         .then(putResponse => {
             winston.debug(`Added target '${targetArn}' to rule '${ruleName}'`);
             return targetId;
+        });
+}
+
+exports.getTargets = function (ruleName) {
+    const cloudWatchEvents = new AWS.CloudWatchEvents({ apiVersion: '2015-10-07' });
+    let listParams = {
+        Rule: ruleName
+    };
+    return cloudWatchEvents.listTargetsByRule(listParams).promise()
+        .then(listResponse => {
+            return listResponse.Targets;
+        });
+}
+
+exports.getRule = function (ruleName) {
+    const cloudWatchEvents = new AWS.CloudWatchEvents({ apiVersion: '2015-10-07' });
+    let listParams = {
+        NamePrefix: ruleName
+    };
+    return cloudWatchEvents.listRules(listParams).promise()
+        .then(listResponse => {
+            for(let rule of listResponse.Rules) {
+                if(rule.Name === ruleName) {
+                    return rule;
+                }
+            }
+            return null;
+        });
+}
+
+exports.removeTargets = function (ruleName, targets) {
+    const cloudWatchEvents = new AWS.CloudWatchEvents({ apiVersion: '2015-10-07' });
+
+    let targetIds = [];
+    for (let target of targets) {
+        targetIds.push(target.Id);
+    }
+
+    let deleteParams = {
+        Ids: targetIds,
+        Rule: ruleName
+    };
+    return cloudWatchEvents.removeTargets(deleteParams).promise()
+        .then(removeResponse => {
+            if (removeResponse.FailedEntryCount > 0) {
+                return false;
+            }
+            else {
+                return true;
+            }
+        });
+}
+
+
+exports.removeAllTargets = function (ruleName) {
+    return exports.getTargets(ruleName)
+        .then(targets => {
+            if (targets.length > 0) {
+                return exports.removeTargets(ruleName, targets)
+            }
+            else {
+                return true;
+            }
         });
 }

--- a/lib/aws/ec2-calls.js
+++ b/lib/aws/ec2-calls.js
@@ -9,12 +9,12 @@ const winston = require('winston');
  * @param {String} vpcId - The ID of the VPC in which to look for the security group
  * @returns {Promise.<SecurityGroup>} - A Promise of the security group information, or null if none exists
  */
-exports.getSecurityGroup = function(groupName, vpcId) {
+exports.getSecurityGroup = function (groupName, vpcId) {
     const ec2 = new AWS.EC2({
         apiVersion: '2016-11-15'
     });
     let describeSgParams = {
-            Filters: [
+        Filters: [
             {
                 Name: 'vpc-id',
                 Values: [vpcId]
@@ -28,7 +28,7 @@ exports.getSecurityGroup = function(groupName, vpcId) {
     winston.debug(`Getting security group ${groupName} in VPC ${vpcId}`);
     return ec2.describeSecurityGroups(describeSgParams).promise()
         .then(describeResults => {
-            if(describeResults['SecurityGroups'].length > 0) {
+            if (describeResults['SecurityGroups'].length > 0) {
                 winston.debug(`Found security group ${groupName} in VPC ${vpcId}`);
                 return describeResults['SecurityGroups'][0];
             }
@@ -39,12 +39,12 @@ exports.getSecurityGroup = function(groupName, vpcId) {
         });
 }
 
-exports.getSecurityGroupById = function(groupId, vpcId) {
+exports.getSecurityGroupById = function (groupId, vpcId) {
     const ec2 = new AWS.EC2({
         apiVersion: '2016-11-15'
     });
     let describeSgParams = {
-            Filters: [
+        Filters: [
             {
                 Name: 'vpc-id',
                 Values: [vpcId]
@@ -58,7 +58,7 @@ exports.getSecurityGroupById = function(groupId, vpcId) {
     winston.debug(`Getting security group ${groupId} in VPC ${vpcId}`);
     return ec2.describeSecurityGroups(describeSgParams).promise()
         .then(describeResults => {
-            if(describeResults['SecurityGroups'].length > 0) {
+            if (describeResults['SecurityGroups'].length > 0) {
                 winston.debug(`Found security group ${groupId} in VPC ${vpcId}`);
                 return describeResults['SecurityGroups'][0];
             }
@@ -69,12 +69,12 @@ exports.getSecurityGroupById = function(groupId, vpcId) {
         });
 }
 
-exports.ingressRuleExists = function(securityGroup, startPort, endPort, protocol, sourceSg) {
+exports.ingressRuleExists = function (securityGroup, startPort, endPort, protocol, sourceSg) {
     let ingressRuleExists = false;
-    for(let ingressRule of securityGroup['IpPermissions']) {
-        if(ingressRule['FromPort'] == startPort && ingressRule['ToPort'] == endPort && ingressRule['IpProtocol'] === protocol) {
-            for(let ingressRuleSource of ingressRule['UserIdGroupPairs']) {
-                if(ingressRuleSource['GroupId'] === sourceSg['GroupId']) {
+    for (let ingressRule of securityGroup['IpPermissions']) {
+        if (ingressRule['FromPort'] == startPort && ingressRule['ToPort'] == endPort && ingressRule['IpProtocol'] === protocol) {
+            for (let ingressRuleSource of ingressRule['UserIdGroupPairs']) {
+                if (ingressRuleSource['GroupId'] === sourceSg['GroupId']) {
                     ingressRuleExists = true;
                     break;
                 }
@@ -84,16 +84,48 @@ exports.ingressRuleExists = function(securityGroup, startPort, endPort, protocol
     return ingressRuleExists;
 }
 
-exports.addIngressRuleToSgIfNotExists = function(sourceSg, destSg, 
-                                                 protocol, startPort, 
-                                                 endPort, vpcId) {
+exports.removeAllIngressFromSg = function (sgName, vpcId) {
+    const ec2 = new AWS.EC2({
+        apiVersion: '2016-11-15'
+    });
+    return exports.getSecurityGroup(sgName, vpcId)
+        .then(sg => {
+            if (sg) {
+                let ipPermissionsToRevoke = [];
+                for (let ipPermission of sg.IpPermissions) {
+                    ipPermissionsToRevoke.push({
+                        IpProtocol: ipPermission.IpProtocol,
+                        FromPort: ipPermission.FromPort,
+                        ToPort: ipPermission.ToPort,
+                        UserIdGroupPairs: ipPermission.UserIdGroupPairs
+                    });
+                }
+
+                var revokeParam = {
+                    GroupId: sg.GroupId,
+                    IpPermissions: ipPermissionsToRevoke
+                };
+                return ec2.revokeSecurityGroupIngress(revokeParam).promise()
+                    .then(result => {
+                        return true;
+                    });
+            }
+            else {
+                return true; //Sg has already been deleted
+            }
+        });
+}
+
+exports.addIngressRuleToSgIfNotExists = function (sourceSg, destSg,
+    protocol, startPort,
+    endPort, vpcId) {
     return exports.getSecurityGroup(destSg['GroupName'], destSg['VpcId'])
         .then(securityGroup => {
-            if(securityGroup) {
-                if(!exports.ingressRuleExists(securityGroup, startPort, endPort, protocol, sourceSg)) {
-                    return exports.addIngressRuleToSecurityGroup(sourceSg, destSg, 
-                                                                 protocol, startPort, 
-                                                                 endPort, vpcId);
+            if (securityGroup) {
+                if (!exports.ingressRuleExists(securityGroup, startPort, endPort, protocol, sourceSg)) {
+                    return exports.addIngressRuleToSecurityGroup(sourceSg, destSg,
+                        protocol, startPort,
+                        endPort, vpcId);
                 }
                 else {
                     return destSg;
@@ -102,14 +134,14 @@ exports.addIngressRuleToSgIfNotExists = function(sourceSg, destSg,
             else {
                 throw new Error("addIngressRuleToSgIfNotExists - missing security group");
             }
-        }); 
+        });
 }
 
 
 //TODO - Document this
-exports.addIngressRuleToSecurityGroup = function(sourceSg, destSg, 
-                                                 protocol, startPort, 
-                                                 endPort, vpcId) {
+exports.addIngressRuleToSecurityGroup = function (sourceSg, destSg,
+    protocol, startPort,
+    endPort, vpcId) {
     const ec2 = new AWS.EC2({
         apiVersion: '2016-11-15'
     });
@@ -133,6 +165,6 @@ exports.addIngressRuleToSecurityGroup = function(sourceSg, destSg,
     return ec2.authorizeSecurityGroupIngress(addIngressParams).promise()
         .then(authorizeResult => {
             winston.debug(`Added ingress rule to security group ${destSg.GroupId} from group ${sourceSg.GroupId}`);
-            return exports.getSecurityGroup(destSg['GroupName'], vpcId);    
+            return exports.getSecurityGroup(destSg['GroupName'], vpcId);
         });
 }

--- a/lib/aws/sqs-calls.js
+++ b/lib/aws/sqs-calls.js
@@ -1,7 +1,5 @@
 const AWS = require('aws-sdk');
 const winston = require('winston');
-const uuid = require('uuid');
-const accountConfig = require('../util/account-config')().getAccountConfig();
 
 
 function getPermissionInPolicyDoc(policyDoc, policyStatement) {

--- a/lib/cli/index.js
+++ b/lib/cli/index.js
@@ -3,6 +3,7 @@ const yaml = require('js-yaml');
 const path = require('path');
 const winston = require('winston');
 const util = require('../util/util');
+const inquirer = require('inquirer');
 
 function getAbsoluteConfigFilePath(filePath) {
     var absolutePath;
@@ -16,7 +17,7 @@ function getAbsoluteConfigFilePath(filePath) {
     return absolutePath;
 }
 
-exports.validateAccountConfigParam = function(accountConfigParam) {
+exports.validateAccountConfigParam = function (accountConfigParam) {
     let errors = [];
     if (!fs.existsSync(accountConfigParam)) { //If not a path, check whether it's base64 encoded json
         try {
@@ -29,18 +30,18 @@ exports.validateAccountConfigParam = function(accountConfigParam) {
     return errors;
 }
 
-exports.validateEnvsInHandelFile = function(envsToDeploy, handelFile) {
+exports.validateEnvsInHandelFile = function (envsToDeploy, handelFile) {
     let errors = [];
     let envsArray = envsToDeploy.split(',');
-    for(let env of envsArray) {
-        if(!handelFile.environments || !handelFile.environments[env]) {
+    for (let env of envsArray) {
+        if (!handelFile.environments || !handelFile.environments[env]) {
             errors.push(`Environment '${env}' was not found in your Handel file`);
         }
     }
     return errors;
 }
 
-exports.validateDeployArgs = function(argv, handelFile) {
+exports.validateDeployArgs = function (argv, handelFile) {
     let errors = [];
 
     //Require account config
@@ -63,15 +64,33 @@ exports.validateDeployArgs = function(argv, handelFile) {
     if (!argv.v) {
         errors.push("The '-v' parameter is required");
     }
-    
+
     return errors;
 }
 
-exports.validateDeleteArgs = function() {
-    throw new Error("DEPLOY ACTION IS NOT IMPLEMENTED YET!");
+exports.validateDeleteArgs = function (argv, handelFile) {
+    let errors = [];
+
+    //Require account config
+    if (!argv.c) {
+        errors.push("The '-c' parameter is required");
+    }
+    else { //Validate that it is either base64 decodable JSON or an account config file
+        errors = errors.concat(exports.validateAccountConfigParam(argv.c));
+    }
+
+    //Require environments to deploy
+    if (!argv.e) {
+        errors.push("The '-e' parameter is required");
+    }
+    else { //Validate that the environments exist in the Handel file
+        errors = errors.concat(exports.validateEnvsInHandelFile(argv.e, handelFile));
+    }
+
+    return errors;
 }
 
-exports.getAccountConfigFilePath = function(configFilePath) {
+exports.getAccountConfigFilePath = function (configFilePath) {
     if (!configFilePath) {
         winston.error("Missing account-config-file parameter");
         process.exit(1);
@@ -79,8 +98,8 @@ exports.getAccountConfigFilePath = function(configFilePath) {
     return getAbsoluteConfigFilePath(configFilePath);
 }
 
-exports.loadAccountConfig = function(accountConfigParam) {
-    if(fs.existsSync(accountConfigParam)) {
+exports.loadAccountConfig = function (accountConfigParam) {
+    if (fs.existsSync(accountConfigParam)) {
         let absoluteConfigFilePath = exports.getAccountConfigFilePath(accountConfigParam);
         return util.readYamlFileSync(absoluteConfigFilePath);
     }
@@ -89,3 +108,40 @@ exports.loadAccountConfig = function(accountConfigParam) {
     }
 }
 
+exports.confirmDelete = function (envName) {
+    const warnMsg = `
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!    
+WARNING: YOU ARE ABOUT TO DELETE YOUR HANDEL ENVIRONMENT '${envName}'!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+If you choose to delete this environment, you will lose all data stored in the environment! 
+
+In particular, you will lose all data in the following:
+
+* Databases
+* Caches
+* S3 Buckets
+* EFS Mounts
+
+PLEASE REVIEW this environment thoroughly, as you are responsible for all data loss associated with an accidental deletion.
+PLEASE BACKUP your data sources before deleting this environment just to be safe.
+`;
+    console.log(warnMsg);
+
+    let questions = [
+        {
+            type: 'input',
+            name: 'confirmDelete',
+            message: `Enter 'yes' to delete your environment. Handel will refuse to delete the environment with any other answer:`
+        }
+    ]
+    return inquirer.prompt(questions)
+        .then(answers => {
+            if(answers.confirmDelete === 'yes') {
+                return true;
+            }
+            else {
+                return false;
+            }
+        });
+}

--- a/lib/datatypes/un-bind-context.js
+++ b/lib/datatypes/un-bind-context.js
@@ -1,0 +1,10 @@
+class UnBindContext {
+    constructor(serviceContext) {
+        this.appName = serviceContext.appName;
+        this.environmentName = serviceContext.environmentName;
+        this.serviceName = serviceContext.serviceName;
+        this.serviceType = serviceContext.serviceType;
+    }
+}
+
+module.exports = exports = UnBindContext;

--- a/lib/datatypes/un-deploy-context.js
+++ b/lib/datatypes/un-deploy-context.js
@@ -1,0 +1,10 @@
+class UnDeployContext {
+    constructor(serviceContext) {
+        this.appName = serviceContext.appName;
+        this.environmentName = serviceContext.environmentName;
+        this.serviceName = serviceContext.serviceName;
+        this.serviceType = serviceContext.serviceType;
+    }
+}
+
+module.exports = exports = UnDeployContext;

--- a/lib/datatypes/un-pre-deploy-context.js
+++ b/lib/datatypes/un-pre-deploy-context.js
@@ -1,0 +1,10 @@
+class UnPreDeployContext {
+    constructor(serviceContext) {
+        this.appName = serviceContext.appName;
+        this.environmentName = serviceContext.environmentName;
+        this.serviceName = serviceContext.serviceName;
+        this.serviceType = serviceContext.serviceType;
+    }
+}
+
+module.exports = exports = UnPreDeployContext;

--- a/lib/handel.js
+++ b/lib/handel.js
@@ -6,11 +6,22 @@ const bindLifecycle = require('./lifecycle/bind');
 const deployLifecycle = require('./lifecycle/deploy');
 const preDeployLifecycle = require('./lifecycle/pre-deploy');
 const checkLifecycle = require('./lifecycle/check');
+const unDeployLifecycle = require('./lifecycle/un-deploy');
+const unPreDeployLifecycle = require('./lifecycle/un-pre-deploy');
+const unBindLifecycle = require('./lifecycle/un-bind');
 const consumeEventsLifecycle = require('./lifecycle/consume-events');
 const produceEventsLifecycle = require('./lifecycle/produce-events');
 const config = require('./util/account-config');
 
 class EnvironmentDeployResult {
+    constructor(status, message, error) {
+        this.status = status;
+        this.message = message;
+        this.error = error;
+    }
+}
+
+class EnvironmentDeleteResult {
     constructor(status, message, error) {
         this.status = status;
         this.message = message;
@@ -53,8 +64,8 @@ function bindAndDeployServices(serviceDeployers, environmentContext, preDeployCo
                     deployContexts[serviceName] = levelDeployResults[serviceName]
                 }
                 return {
-                    bindContexts: bindContexts,
-                    deployContexts: deployContexts
+                    bindContexts,
+                    deployContexts
                 }
             });
     }
@@ -73,6 +84,33 @@ function setupEventBindings(serviceDeployers, environmentContext, deployContexts
                     };
                 });
         });
+}
+
+function unDeployAndUnBindServices(serviceDeployers, environmentContext, deployOrder) {
+    let deleteProcess = Promise.resolve();
+    let unBindContexts = {};
+    let unDeployContexts = {};
+    for(let currentLevel = deployOrder.length-1; deployOrder[currentLevel]; currentLevel--) {
+        deleteProcess = deleteProcess
+            .then(() => unDeployLifecycle.unDeployServicesInLevel(serviceDeployers, environmentContext, deployOrder, currentLevel))
+            .then(levelUnDeployResults => {
+                for(let serviceName in levelUnDeployResults) {
+                    unDeployContexts[serviceName] = levelUnDeployResults[serviceName];
+                }
+            })
+            .then(() => unBindLifecycle.unBindServicesInLevel(serviceDeployers, environmentContext, deployOrder, currentLevel))
+            .then(levelUnBindResults => {
+                for(let serviceName in levelUnBindResults) {
+                    unBindContexts[serviceName] = levelUnBindResults[serviceName]
+                }
+                return {
+                    unBindContexts,
+                    unDeployContexts
+                }
+            });
+    }
+    
+    return deleteProcess;
 }
 
 /**
@@ -109,6 +147,27 @@ function deployEnvironment(accountConfig, serviceDeployers, environmentContext) 
         else {
             return Promise.resolve(new EnvironmentDeployResult("failure", `Errors while checking deploy spec: \n${errors.join("\n")}`));
         }
+    }
+}
+
+function deleteEnvironment(accountConfig, serviceDeployers, environmentContext) {
+    if(!accountConfig || !environmentContext) {
+        return Promise.resolve(new EnvironmentDeployResult("failure", "Invalid configuration"));
+    }
+    else {
+        winston.info(`Starting delete for environment ${environmentContext.environmentName}`);
+
+        let deployOrder = deployOrderCalc.getDeployOrder(environmentContext);
+        return unDeployAndUnBindServices(serviceDeployers, environmentContext, deployOrder)
+            .then(unDeployAndUnBindResults => {
+                return unPreDeployLifecycle.unPreDeployServices(serviceDeployers, environmentContext)
+            })
+            .then(unPreDeployResults => {
+                return new EnvironmentDeleteResult("success");
+            })
+            .catch(err => {
+                return new EnvironmentDeleteResult("failure", err.message, err);
+            });
     }
 }
 
@@ -158,8 +217,34 @@ exports.check = function(handelFile, environmentsToDeploy, deployVersion) {
     }
 }
 
-exports.delete = function() {
+exports.delete = function(newAccountConfig, handelFile, environmentToDelete) {
+    return new Promise((resolve, reject) => {
+        try {
+            //Pull account-level config from the provided file so it can be consumed by the library
+            let accountConfig = config(newAccountConfig).getAccountConfig();
 
+            //Set up AWS SDK with any global options
+            configureAwsSdk(accountConfig);
+
+            //Load all the currently implemented service deployers from the 'services' directory
+            let serviceDeployers = util.getServiceDeployers();
+
+            //Load Handel file from path and validate it
+            winston.info("Validating and parsing Handel file");
+            let handelFileParser = util.getHandelFileParser(handelFile);
+            handelFileParser.validateHandelFile(handelFile, serviceDeployers);
+
+            //Run the delete on the environment specified
+            let environmentContext = createEnvironmentContext(handelFile, handelFileParser, environmentToDelete, "1"); //Use fake version since we're deleting it
+            deleteEnvironment(accountConfig, serviceDeployers, environmentContext)
+                .then(result => {
+                    resolve(result);
+                });
+        }
+        catch(err) {
+            reject(err);
+        }
+    });
 }
 
 exports.deploy = function(newAccountConfig, handelFile, environmentsToDeploy, deployVersion) {

--- a/lib/lifecycle/bind.js
+++ b/lib/lifecycle/bind.js
@@ -1,61 +1,54 @@
 const winston = require('winston');
 const util = require('../util/util');
 const BindContext = require('../datatypes/bind-context');
-const _ = require('lodash');
 
-function getDependentServicesForCurrentBindService(environmentContext, toBindServiceName) {
+exports.getDependentServicesForCurrentBindService = function (environmentContext, toBindServiceName) {
     let dependentServices = [];
-    for(let currentServiceName in environmentContext.serviceContexts) {
+    for (let currentServiceName in environmentContext.serviceContexts) {
         let currentService = environmentContext.serviceContexts[currentServiceName];
         let currentServiceDeps = currentService.params.dependencies;
-        if(currentServiceDeps && currentServiceDeps.includes(toBindServiceName)) {
+        if (currentServiceDeps && currentServiceDeps.includes(toBindServiceName)) {
             dependentServices.push(currentServiceName);
         }
     }
     return dependentServices;
 }
 
-exports.bindServicesInLevel = function(serviceDeployers, 
-                                       environmentContext, 
-                                       preDeployContexts, 
-                                       deployOrder, 
-                                       levelToBind) {
-    winston.info(`Executing bind on level ${levelToBind} of services`);
-    let bindInternalPromises = [];
+exports.bindServicesInLevel = function (serviceDeployers, environmentContext, preDeployContexts, deployOrder, levelToBind) {
+    let bindPromises = [];
     let levelBindContexts = {};
 
     let currentLevelServicesToBind = deployOrder[levelToBind];
-    winston.info(`Binding service dependencies (if any) on level ${levelToBind} for services ${currentLevelServicesToBind.join(', ')}`);
-    for(let i = 0; i < currentLevelServicesToBind.length; i++) {
+    winston.info(`Executing bind (if any) on service dependencies on level ${levelToBind} for services ${currentLevelServicesToBind.join(', ')}`);
+    for (let i = 0; i < currentLevelServicesToBind.length; i++) {
         let toBindServiceName = currentLevelServicesToBind[i];
 
         //Get ServiceContext and PreDeployContext for the service to call bind on
         let toBindServiceContext = environmentContext.serviceContexts[toBindServiceName];
-        let serviceDeployer = serviceDeployers[toBindServiceContext.serviceType];
         let toBindPreDeployContext = preDeployContexts[toBindServiceName];
-
+        let serviceDeployer = serviceDeployers[toBindServiceContext.serviceType];
 
         //This service may have multiple services dependening on it, run bind on each of them
-        for(let dependentOfServiceName of getDependentServicesForCurrentBindService(environmentContext, toBindServiceName)) {
+        for (let dependentOfServiceName of exports.getDependentServicesForCurrentBindService(environmentContext, toBindServiceName)) {
             //Get ServiceContext and PreDeployContext for the service dependency
             let dependentOfServiceContext = environmentContext.serviceContexts[dependentOfServiceName];
             let dependentOfPreDeployContext = preDeployContexts[dependentOfServiceName];
 
             //Run bind on the service combination
             let bindContextName = util.getBindContextName(toBindServiceName, dependentOfServiceName)
-            winston.info(`Binding internal service ${bindContextName}`);
+            winston.info(`Binding service ${bindContextName}`);
             let bindPromise = serviceDeployer.bind(toBindServiceContext, toBindPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext)
                 .then(bindContext => {
-                    if(!(bindContext instanceof BindContext)) {
+                    if (!(bindContext instanceof BindContext)) {
                         throw new Error("Expected BindContext back from 'bind' phase of service deployer");
                     }
                     levelBindContexts[bindContextName] = bindContext;
                 });
-            bindInternalPromises.push(bindPromise);
+            bindPromises.push(bindPromise);
         }
     }
 
-    return Promise.all(bindInternalPromises)
+    return Promise.all(bindPromises)
         .then(() => {
             return levelBindContexts; //This was built up at each bind above
         });

--- a/lib/lifecycle/pre-deploy.js
+++ b/lib/lifecycle/pre-deploy.js
@@ -4,27 +4,24 @@ const PreDeployContext = require('../datatypes/pre-deploy-context');
 
 exports.preDeployServices = function(serviceDeployers, environmentContext) {
     winston.info(`Executing pre-deploy on services in environment ${environmentContext.environmentName}`);
-
     let preDeployPromises = [];
+    let preDeployContexts = {};
 
      _.forEach(environmentContext.serviceContexts, function(serviceContext) {
         winston.info(`Executing pre-deploy on service ${serviceContext.serviceName}`);
         let serviceDeployer = serviceDeployers[serviceContext.serviceType];
-        preDeployPromises.push(serviceDeployer.preDeploy(serviceContext));
-    });
-
-    return Promise.all(preDeployPromises)
-        .then(preDeployResults => {
-            var preDeployContexts = {}
-            let i = 0;
-            _.forEach(environmentContext.serviceContexts, function(serviceContext) {
-                let preDeployContext = preDeployResults[i];
+        let preDeployPromise = serviceDeployer.preDeploy(serviceContext)
+            .then(preDeployContext => {
                 if(!(preDeployContext instanceof PreDeployContext)) {
                     throw new Error("Expected PreDeployContext as result from 'preDeploy' phase");
                 }
-                preDeployContexts[serviceContext.serviceName] = preDeployContext
-                i++;
+                preDeployContexts[serviceContext.serviceName] = preDeployContext;
             });
-            return preDeployContexts;
-        })
+        preDeployPromises.push(preDeployPromise);
+    });
+
+    return Promise.all(preDeployPromises)
+        .then(() => {
+            return preDeployContexts; //This was built up dynamically above
+        });
 }

--- a/lib/lifecycle/un-bind.js
+++ b/lib/lifecycle/un-bind.js
@@ -1,0 +1,31 @@
+const winston = require('winston');
+const UnBindContext = require('../datatypes/un-bind-context');
+
+exports.unBindServicesInLevel = function (serviceDeployers, environmentContext, deployOrder, level) {
+    let unBindPromises = [];
+    let unBindContexts = {};
+
+    let currentLevelServicesToUnBind = deployOrder[level];
+    winston.info(`Running UnBind on service dependencies (if any) in level ${level} for services ${currentLevelServicesToUnBind.join(', ')}`);
+    for (let i = 0; i < currentLevelServicesToUnBind.length; i++) {
+        let toUnBindServiceName = currentLevelServicesToUnBind[i];
+        let toUnBindServiceContext = environmentContext.serviceContexts[toUnBindServiceName];
+        let serviceDeployer = serviceDeployers[toUnBindServiceContext.serviceType];
+
+        winston.info(`UnBinding service ${toUnBindServiceName}`);
+        
+        let unBindPromise = serviceDeployer.unBind(toUnBindServiceContext)
+            .then(unBindContext => {
+                if(!(unBindContext instanceof UnBindContext)) {
+                    throw new Error("Expected UnBindContext back from 'unBind' phase of service deployer");
+                }
+                unBindContexts[toUnBindServiceName] = unBindContext;
+            });
+        unBindPromises.push(unBindPromise);
+    }
+
+    return Promise.all(unBindPromises)
+        .then(() => {
+            return unBindContexts; //This was built up dynamically above
+        });
+}

--- a/lib/lifecycle/un-deploy.js
+++ b/lib/lifecycle/un-deploy.js
@@ -1,0 +1,32 @@
+const winston = require('winston');
+const UnDeployContext = require('../datatypes/un-deploy-context.js');
+
+exports.unDeployServicesInLevel = function(serviceDeployers, environmentContext, deployOrder, level) {
+    let serviceUnDeployPromises = [];
+    let levelUnDeployContexts = {};
+
+    let currentLevelElements = deployOrder[level];
+    winston.info(`UnDeploying level ${level} of services: ${currentLevelElements.join(', ')}`);
+    for(let i = 0; i < currentLevelElements.length; i++) {
+        let toUnDeployServiceName = currentLevelElements[i];
+        let toUnDeployServiceContext = environmentContext.serviceContexts[toUnDeployServiceName];
+
+        let serviceDeployer = serviceDeployers[toUnDeployServiceContext.serviceType];
+
+        winston.info(`UnDeploying service ${toUnDeployServiceName}`);
+        let serviceUndeployPromise = serviceDeployer.unDeploy(toUnDeployServiceContext)
+            .then(unDeployContext => {
+                if(!(unDeployContext instanceof UnDeployContext)) {
+                    throw new Error("Expected UnDeployContext as result from 'unDeploy' phase");
+                }
+                levelUnDeployContexts[toUnDeployServiceName] = unDeployContext;
+            });
+        
+        serviceUnDeployPromises.push(serviceUndeployPromise);
+    }
+
+    return Promise.all(serviceUnDeployPromises)
+        .then(() => {
+            return levelUnDeployContexts; //This was build up dynamically above
+        });
+}

--- a/lib/lifecycle/un-pre-deploy.js
+++ b/lib/lifecycle/un-pre-deploy.js
@@ -1,0 +1,27 @@
+const winston = require('winston');
+const UnPreDeployContext = require('../datatypes/un-pre-deploy-context');
+
+exports.unPreDeployServices = function(serviceDeployers, environmentContext) {
+    winston.info(`Executing UnPreDeploy on services in environment ${environmentContext.environmentName}`);
+    let unPreDeployPromises = [];
+    let unPreDeployContexts = {};
+
+    for(let serviceName in environmentContext.serviceContexts) {
+        let serviceContext = environmentContext.serviceContexts[serviceName];
+        winston.info(`Executing UnPreDeploy on service ${serviceName}`);
+        let serviceDeployer = serviceDeployers[serviceContext.serviceType];
+        let unPreDeployPromise = serviceDeployer.unPreDeploy(serviceContext)
+            .then(unPreDeployContext => {
+                if(!(unPreDeployContext instanceof UnPreDeployContext)) {
+                    throw new Error("Expected PreDeployContext as result from 'preDeploy' phase");
+                }
+                unPreDeployContexts[serviceContext.serviceName] = unPreDeployContext;
+            });
+        unPreDeployPromises.push(unPreDeployPromise);
+    }
+
+    return Promise.all(unPreDeployPromises)
+        .then(() => {
+            return unPreDeployContexts; //This was built up dynamically above
+        });
+}

--- a/lib/services/apigateway/index.js
+++ b/lib/services/apigateway/index.js
@@ -1,13 +1,13 @@
 const BindContext = require('../../datatypes/bind-context');
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const DeployContext = require('../../datatypes/deploy-context');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 const cloudformationCalls = require('../../aws/cloudformation-calls');
 const util = require('../../util/util');
 const handlebarsUtils = require('../../util/handlebars-utils');
 const deployersCommon = require('../deployers-common');
-const fs = require('fs');
 const uuid = require('uuid');
-const s3Calls = require('../../aws/s3-calls');
 const accountConfig = require('../../util/account-config')().getAccountConfig();
 const winston = require('winston');
 const _ = require('lodash');
@@ -222,6 +222,48 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
  */
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return Promise.reject(new Error("The API Gateway service doesn't produce events for other services"));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function (ownServiceContext) {
+    winston.info(`API Gateway - UnPreDeploy is not required for this service`);
+    return Promise.resolve(new UnPreDeployContext(ownServiceContext));
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function (ownServiceContext) {
+    winston.info(`API Gateway - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'API Gateway');
 }
 
 /**

--- a/lib/services/beanstalk/index.js
+++ b/lib/services/beanstalk/index.js
@@ -6,8 +6,8 @@ const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../util/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployersCommon = require('../deployers-common');
-const ec2Calls = require('../../aws/ec2-calls');
-const fs = require('fs');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 const uuid = require('uuid');
 const util = require('../../util/util');
 const _ = require('lodash');
@@ -287,6 +287,54 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
  */
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return Promise.reject(new Error("The Beanstalk service doesn't produce events for other services"));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function (ownServiceContext) {
+    let sgName = deployersCommon.getResourceName(ownServiceContext);
+    winston.info(`Beanstalk - Executing UnPreDeploy on ${sgName}`);
+
+    return deployersCommon.deleteSecurityGroupForService(sgName)
+        .then(success => {
+            winston.info(`Beanstalk - Finished UnPreDeploy on ${sgName}`);
+            return new UnPreDeployContext(ownServiceContext);
+        });
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function (ownServiceContext) {
+    winston.info(`Beanstalk - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'Beanstalk');
 }
 
 /**

--- a/lib/services/cloudwatchevent/index.js
+++ b/lib/services/cloudwatchevent/index.js
@@ -2,12 +2,13 @@ const winston = require('winston');
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
+const UnDeployContext = require('../../datatypes/un-deploy-context');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 const ProduceEventsContext = require('../../datatypes/produce-events-context');
-const accountConfig = require('../../util/account-config')().getAccountConfig();
 const cloudWatchEventsCalls = require('../../aws/cloudwatch-events-calls');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployersCommon = require('../deployers-common');
-const util = require('../../util/util');
 const handlebarsUtils = require('../../util/handlebars-utils');
 const yaml = require('js-yaml');
 
@@ -37,7 +38,7 @@ function getCompiledEventRuleTemplate(stackName, serviceContext) {
             //NOTE: This is a bit odd, but the syntax of event patterns is complex enough that it's easiest to just provide
             //  a pass-through to the AWS event rule syntax for anyone wanting to specify an event pattern.
             let templateObj = yaml.safeLoad(template);
-            if(serviceParams.event_pattern) {
+            if (serviceParams.event_pattern) {
                 templateObj.Resources.EventsRule.Properties.EventPattern = serviceParams.event_pattern;
             }
             let templateStr = yaml.safeDump(templateObj);
@@ -58,7 +59,7 @@ exports.check = function (serviceContext) {
     let serviceParams = serviceContext.params;
 
     //Require 'schedule' or 'event_pattern'
-    if(!serviceParams.schedule && !serviceParams.event_pattern) {
+    if (!serviceParams.schedule && !serviceParams.event_pattern) {
         errors.push(`CloudWatch Events - You must specify at least one of the 'schedule' or 'event_pattern' parameters`);
     }
 
@@ -187,10 +188,10 @@ exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerS
         let targetId = deployersCommon.getResourceName(consumerServiceContext);
         let targetArn;
         let input;
-        if(consumerServiceType === 'lambda') {
+        if (consumerServiceType === 'lambda') {
             targetArn = consumerDeployContext.eventOutputs.lambdaArn;
             let eventConsumerConfig = deployersCommon.getEventConsumerConfigParams(ownServiceContext, consumerServiceContext);
-            if(!eventConsumerConfig) { throw new Error(`No event_consumer config found in producer service for '${consumerServiceContext.serviceName}'`); }
+            if (!eventConsumerConfig) { throw new Error(`No event_consumer config found in producer service for '${consumerServiceContext.serviceName}'`); }
             input = eventConsumerConfig.event_input;
         }
         else {
@@ -203,8 +204,78 @@ exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerS
                 return resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
             });
     });
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function (ownServiceContext) {
+    winston.info(`CloudWatch Events - UnPreDeploy is not required for this service`);
+    return Promise.resolve(new UnPreDeployContext(ownServiceContext));
+}
 
 
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function (ownServiceContext) {
+    winston.info(`CloudWatch Events - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    let stackName = deployersCommon.getResourceName(ownServiceContext);
+    winston.info(`CloudWatch Events - Executing UnDeploy on Events Rule '${stackName}'`)
+
+    
+    return cloudWatchEventsCalls.getRule(stackName)
+        .then(rule => {
+            if (rule) {
+                winston.info(`CloudWatch Events - Removing targets from event rule '${stackName}'`);
+                return cloudWatchEventsCalls.removeAllTargets(stackName)
+            }
+            else {
+                winston.info(`CloudWatch Events - Rule '${stackName}' has already been deleted`);
+                return true;
+            }
+        })
+        .then(success => {
+            return cloudFormationCalls.getStack(stackName)
+                .then(stack => {
+                    if (stack) {
+                        winston.info(`CloudWatch Events - Deleting events rule stack '${stackName}'`);
+                        return cloudFormationCalls.deleteStack(stackName);
+                    }
+                    else {
+                        winston.info(`CloudWatch Events - Stack '${stackName}' has already been deleted`);
+                    }
+                });
+        })
+        .then(() => {
+            return new UnDeployContext(ownServiceContext);
+        });
 }
 
 /**

--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -2,6 +2,8 @@ const iamCalls = require('../aws/iam-calls');
 const s3Calls = require('../aws/s3-calls');
 const ec2Calls = require('../aws/ec2-calls');
 const cloudformationCalls = require('../aws/cloudformation-calls');
+const UnDeployContext = require('../datatypes/un-deploy-context');
+const winston = require('winston');
 const accountConfig = require('../util/account-config')().getAccountConfig();
 const fs = require('fs');
 const util = require('../util/util');
@@ -102,6 +104,46 @@ exports.createSecurityGroupForService = function (stackName, addSshIngress) {
         .then(deployedStack => {
             let groupId = cloudformationCalls.getOutput('GroupId', deployedStack)
             return ec2Calls.getSecurityGroupById(groupId, accountConfig.vpc);
+        });
+}
+
+exports.unBindAllOnSg = function(stackName) {
+    let sgName = `${stackName}-sg`;
+    return ec2Calls.removeAllIngressFromSg(sgName, accountConfig.vpc)
+        .then(() => {
+            return true;
+        });
+}
+
+exports.deleteSecurityGroupForService = function(stackName) {
+    let sgName = `${stackName}-sg`;
+    return cloudformationCalls.getStack(sgName)
+        .then(stack => {
+            if(stack) {
+                return cloudformationCalls.deleteStack(sgName)
+            }
+            else {
+                return true;
+            }
+        });
+}
+
+exports.unDeployCloudFormationStack = function(serviceContext, serviceType) {
+    let stackName = exports.getResourceName(serviceContext);
+    winston.info(`${serviceType} - Executing UnDeploy on '${stackName}'`)
+
+    return cloudformationCalls.getStack(stackName)
+        .then(stack => {
+            if (stack) {
+                winston.info(`${serviceType} - Deleting stack '${stackName}'`);
+                return cloudformationCalls.deleteStack(stackName);
+            }
+            else {
+                winston.info(`${serviceType} - Stack '${stackName}' has already been deleted`);
+            }
+        })
+        .then(() => {
+            return new UnDeployContext(serviceContext);
         });
 }
 

--- a/lib/services/dynamodb/index.js
+++ b/lib/services/dynamodb/index.js
@@ -7,6 +7,8 @@ const util = require('../../util/util');
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 const keyTypeToAttributeType = {
     String: "S",
     Number: "N"
@@ -43,7 +45,7 @@ function getTablePolicyForDependentServices(table) {
 function getDeployContext(serviceContext, table) {
     let deployContext = new DeployContext(serviceContext);
     deployContext.policies.push(getTablePolicyForDependentServices(table));
-    
+
     let tableNameEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'TABLE_NAME');
     deployContext.environmentVariables[tableNameEnv] = table.TableName;
     let tableArnEnv = deployersCommon.getInjectedEnvVarName(serviceContext, 'TABLE_ARN');
@@ -61,7 +63,7 @@ function getTable(dynamodb, tableName) {
             return tableData.Table;
         })
         .catch(err => {
-            if(err.statusCode === 400 && err.code === 'ResourceNotFoundException') {
+            if (err.statusCode === 400 && err.code === 'ResourceNotFoundException') {
                 winston.info(`Table ${tableName} does not exist`);
                 return null;
             }
@@ -77,16 +79,16 @@ function getCloudFormationStackParams(stackName, serviceParams) {
     }
 
     //Add sort key if provided
-    if(serviceParams.sort_key) {
+    if (serviceParams.sort_key) {
         stackParams.SortKeyName = serviceParams.sort_key.name,
-        stackParams.SortKeyType = keyTypeToAttributeType[serviceParams.sort_key.type]
+            stackParams.SortKeyType = keyTypeToAttributeType[serviceParams.sort_key.type]
     }
 
     //Add provisioned throughput if provided
-    if(serviceParams.provisioned_throughput && serviceParams.provisioned_throughput.read_capacity_units) {
+    if (serviceParams.provisioned_throughput && serviceParams.provisioned_throughput.read_capacity_units) {
         stackParams.ReadCapacityUnits = serviceParams.provisioned_throughput.read_capacity_units.toString();
     }
-    if(serviceParams.provisioned_throughput && serviceParams.provisioned_throughput.write_capacity_units) {
+    if (serviceParams.provisioned_throughput && serviceParams.provisioned_throughput.write_capacity_units) {
         stackParams.WriteCapacityUnits = serviceParams.provisioned_throughput.write_capacity_units.toString();
     }
 
@@ -100,18 +102,18 @@ function getCloudFormationStackParams(stackName, serviceParams) {
  * @param {ServiceContext} serviceContext - The ServiceContext for the service to check
  * @returns {Array} - 0 or more String error messages
  */
-exports.check = function(serviceContext) {
+exports.check = function (serviceContext) {
     let errors = [];
     let params = serviceContext.params;
 
-    if(!params.partition_key) {
+    if (!params.partition_key) {
         errors.push("DynamoDB - partition_key section is required");
     }
     else {
-        if(!params.partition_key.name) {
+        if (!params.partition_key.name) {
             errors.push("DynamoDB - name field in partition_key is required");
         }
-        if(!params.partition_key.type) {
+        if (!params.partition_key.type) {
             errors.push("DynamoDB - type field in partition_key is required");
         }
     }
@@ -126,7 +128,7 @@ exports.check = function(serviceContext) {
  * @param {ServiceContext} serviceContext - The ServiceContext for the service to check
  * @returns {Promise.<PreDeployContext>} - A Promise of the PreDeployContext results from the pre-deploy
  */
-exports.preDeploy = function(serviceContext) {
+exports.preDeploy = function (serviceContext) {
     winston.info(`DynamoDB - PreDeploy not required for this service, skipping it`);
     return Promise.resolve(new PreDeployContext(serviceContext));
 }
@@ -149,7 +151,7 @@ exports.preDeploy = function(serviceContext) {
  * @param {PreDeployContext} dependentOfPreDeployContext - The PreDeployContext of the service consuming this one
  * @returns {Promise.<BindContext>} - A Promise of the BindContext results from the Bind
  */
-exports.bind = function(ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
+exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
     winston.info(`DynamoDB - Bind not required for this service, skipping it`);
     return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
 }
@@ -165,7 +167,7 @@ exports.bind = function(ownServiceContext, ownPreDeployContext, dependentOfServi
  * @param {Array<DeployContext>} dependenciesDeployContexts - The DeployContexts of the services that this one depends on
  * @returns {Promise.<DeployContext>} - A Promise of the DeployContext from this deploy
  */
-exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
+exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
     const dynamodb = new AWS.DynamoDB({ //I do this here because the aws-mock tool I use requires it
         apiVersion: '2012-08-10'
     });
@@ -174,7 +176,7 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
 
     return cloudFormationCalls.getStack(stackName)
         .then(stack => {
-            if(!stack) { //Create
+            if (!stack) { //Create
                 let dynamoTemplate = util.readFileSync(`${__dirname}/dynamodb.yml`);
                 let stackParams = getCloudFormationStackParams(stackName, ownServiceContext.params);
 
@@ -217,8 +219,8 @@ exports.deploy = function(ownServiceContext, ownPreDeployContext, dependenciesDe
  * @param {DeployContext} producerDeployContext - The DeployContext of the service that will be producing events for this service.
  * @returns {Promise.<ConsumeEventsContext>} - The information about the event consumption for this service
  */
-exports.consumeEvents = function(ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
-    return Promise.reject(new Error("The DynamoDB service doesn't consume events from other services"));
+exports.consumeEvents  =  function (ownServiceContext,  ownDeployContext,  producerServiceContext,  producerDeployContext)  {
+        return  Promise.reject(new Error("The DynamoDB service doesn't consume events from other services"));
 }
 
 /**
@@ -239,8 +241,51 @@ exports.consumeEvents = function(ownServiceContext, ownDeployContext, produc
  * @param {DeployContext} producerDeployContext - The DeployContext of the service that will be consuming events for this service.
  * @returns {Promise.<ProduceEventsContext>} - The information about the event consumption for this service
  */
-exports.produceEvents = function(ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
-    return Promise.reject(new Error("The DynamoDB service doesn't produce events for other services"));
+exports.produceEvents  =  function (ownServiceContext,  ownDeployContext,  consumerServiceContext,  consumerDeployContext)  {
+        return  Promise.reject(new Error("The DynamoDB service doesn't produce events for other services"));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function (ownServiceContext) {
+    winston.info(`DynamoDB - UnPreDeploy is not required for this service`);
+    return Promise.resolve(new UnPreDeployContext(ownServiceContext));
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function (ownServiceContext) {
+    winston.info(`DynamoDB - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'DynamoDB');
 }
 
 /**
@@ -248,7 +293,7 @@ exports.produceEvents = function(ownServiceContext, ownDeployContext, consum
  * 
  * If the list is empty, this service cannot produce events to other services.
  */
-exports.producedEventsSupportedServices = [];
+exports.producedEventsSupportedServices  =  [];
 
 
 /**

--- a/lib/services/ecs/index.js
+++ b/lib/services/ecs/index.js
@@ -1,12 +1,11 @@
 const winston = require('winston');
-const ec2Calls = require('../../aws/ec2-calls');
 const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 const accountConfig = require('../../util/account-config')().getAccountConfig();
-const iamCalls = require('../../aws/iam-calls');
 const deployersCommon = require('../deployers-common');
-const util = require('../../util/util');
 const handlebarsUtils = require('../../util/handlebars-utils');
 const cloudformationCalls = require('../../aws/cloudformation-calls');
 const _ = require('lodash');
@@ -418,6 +417,55 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
  */
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return Promise.reject(new Error("The ECS service doesn't produce events for other services"));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function (ownServiceContext) {
+    let sgName = deployersCommon.getResourceName(ownServiceContext);
+    winston.info(`ECS - Executing UnPreDeploy on ${sgName}`);
+
+    return deployersCommon.deleteSecurityGroupForService(sgName)
+        .then(success => {
+            winston.info(`ECS - Finished UnPreDeploy on ${sgName}`);
+            return new UnPreDeployContext(ownServiceContext);
+        });
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function (ownServiceContext) {
+    winston.info(`ECS - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'ECS');
 }
 
 /**

--- a/lib/services/efs/index.js
+++ b/lib/services/efs/index.js
@@ -7,7 +7,8 @@ const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../util/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployersCommon = require('../deployers-common');
-const util = require('../../util/util');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 
 const EFS_PORT = 2049;
 const EFS_SG_PROTOCOL = "tcp";
@@ -238,6 +239,61 @@ exports.consumeEvents = function(ownServiceContext, ownDeployContext, produc
  */
 exports.produceEvents = function(ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return Promise.reject(new Error("The EFS service doesn't produce events for other services"));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function (ownServiceContext) {
+    let sgName = deployersCommon.getResourceName(ownServiceContext);
+    winston.info(`EFS - Executing UnPreDeploy on ${sgName}`);
+
+    return deployersCommon.deleteSecurityGroupForService(sgName)
+        .then(success => {
+            winston.info(`EFS - Finished UnPreDeploy on ${sgName}`);
+            return new UnPreDeployContext(ownServiceContext);
+        });
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function (ownServiceContext) {
+    let sgName = deployersCommon.getResourceName(ownServiceContext);
+    winston.info(`EFS - Executing UnBind on ${sgName}`);
+
+    return deployersCommon.unBindAllOnSg(sgName)
+        .then(success => {
+            winston.info(`EFS - Finished UnBind on ${sgName}`);
+            return new UnBindContext(ownServiceContext);
+        });
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'DynamoDB');
 }
 
 /**

--- a/lib/services/lambda/index.js
+++ b/lib/services/lambda/index.js
@@ -4,6 +4,8 @@ const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const ConsumeEventsContext = require('../../datatypes/consume-events-context');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 const util = require('../../util/util');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const lambdaCalls = require('../../aws/lambda-calls');
@@ -244,6 +246,48 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
  */
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return Promise.reject(new Error("The Lambda service doesn't produce events for other services"));
+}
+
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function(ownServiceContext) {
+    winston.info(`Lambda - UnPreDeploy is not required for this service`);
+    return Promise.resolve(new UnPreDeployContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function(ownServiceContext) {
+    winston.info(`Lambda - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'Lambda');
 }
 
 /**

--- a/lib/services/s3/index.js
+++ b/lib/services/s3/index.js
@@ -5,7 +5,8 @@ const DeployContext = require('../../datatypes/deploy-context');
 const accountConfig = require('../../util/account-config')().getAccountConfig();
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployersCommon = require('../deployers-common');
-const util = require('../../util/util');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 const handlebarsUtils = require('../../util/handlebars-utils');
 
 const VERSIONING_PARAM_MAPPING = {
@@ -209,6 +210,47 @@ exports.consumeEvents  =  function (ownServiceContext,  ownDeployContext,  p
 exports.produceEvents  =  function (ownServiceContext,  ownDeployContext,  consumerServiceContext,  consumerDeployContext)  {
     return  Promise.reject(new Error("The S3 service doesn't currently produce events for other services"));
     //     return Promise.resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function(ownServiceContext) {
+    winston.info(`S3 - UnPreDeploy is not required for this service`);
+    return Promise.resolve(new UnPreDeployContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function(ownServiceContext) {
+    winston.info(`S3 - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'S3');
 }
 
 /**

--- a/lib/services/sns/index.js
+++ b/lib/services/sns/index.js
@@ -7,6 +7,8 @@ const DeployContext = require('../../datatypes/deploy-context');
 const snsCalls = require('../../aws/sns-calls');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployersCommon = require('../deployers-common');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 
 function getCompiledSnsTemplate(stackName, serviceContext) {
     let serviceParams = serviceContext.params;
@@ -210,6 +212,47 @@ exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerS
                 return resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
             });
     });
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function(ownServiceContext) {
+    winston.info(`SNS - UnPreDeploy is not required for this service`);
+    return Promise.resolve(new UnPreDeployContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function(ownServiceContext) {
+    winston.info(`SNS - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'SNS');
 }
 
 /**

--- a/lib/services/sqs/index.js
+++ b/lib/services/sqs/index.js
@@ -4,7 +4,8 @@ const PreDeployContext = require('../../datatypes/pre-deploy-context');
 const BindContext = require('../../datatypes/bind-context');
 const DeployContext = require('../../datatypes/deploy-context');
 const ConsumeEventsContext = require('../../datatypes/consume-events-context');
-const accountConfig = require('../../util/account-config')().getAccountConfig();
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
 const cloudFormationCalls = require('../../aws/cloudformation-calls');
 const deployersCommon = require('../deployers-common');
 const sqsCalls = require('../../aws/sqs-calls');
@@ -248,6 +249,48 @@ exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerS
 exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
     return Promise.reject(new Error("The SQS service doesn't produce events for other services"));
 }
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function(ownServiceContext) {
+    winston.info(`SQS - UnPreDeploy is not required for this service`);
+    return Promise.resolve(new UnPreDeployContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function(ownServiceContext) {
+    winston.info(`SQS - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    return deployersCommon.unDeployCloudFormationStack(ownServiceContext, 'SQS');
+}
+
 
 /**
  * List of event sources this service can integrate with.

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "aws-sdk": "^2.9.0",
     "bluebird": "^3.5.0",
     "handlebars": "^4.0.6",
+    "inquirer": "^3.0.6",
     "js-yaml": "3.7.0",
     "lodash": "^4.17.4",
     "minimist": "^1.2.0",

--- a/test/aws/cloudformation-calls-test.js
+++ b/test/aws/cloudformation-calls-test.js
@@ -13,6 +13,7 @@ describe('cloudformationCalls', function() {
 
     afterEach(function() {
         sandbox.restore();
+        AWS.restore('CloudFormation');
     });
 
     describe('getStack', function() {
@@ -27,7 +28,6 @@ describe('cloudformationCalls', function() {
             return cloudformationCalls.getStack(stackName)
                 .then(stack => {
                     expect(stack.StackName).to.equal(stackName);
-                    AWS.restore('CloudFormation');
                 });
         });
 
@@ -40,7 +40,6 @@ describe('cloudformationCalls', function() {
             return cloudformationCalls.getStack(stackName)
                 .then(stack => {
                     expect(stack).to.be.null;
-                    AWS.restore('CloudFormation');
                 });
         });
 
@@ -57,7 +56,6 @@ describe('cloudformationCalls', function() {
                 })
                 .catch(error => {
                     expect(error.code).to.equal(errorCode);
-                    AWS.restore('CloudFormation');
                 });
         });
     });
@@ -74,7 +72,6 @@ describe('cloudformationCalls', function() {
             return cloudformationCalls.waitForStack(stackName, "stackUpdateComplete")
                 .then(stack => {
                     expect(stack.StackName).to.equal(stackName);
-                    AWS.restore('CloudFormation');
                 })
         });
     });
@@ -90,7 +87,6 @@ describe('cloudformationCalls', function() {
             return cloudformationCalls.createStack(stackName, "FakeTemplateBody", [])
                 .then(stack => {
                     expect(stack.StackName).to.equal(stackName);
-                    AWS.restore('CloudFormation');
                 });
         });
     });
@@ -106,7 +102,6 @@ describe('cloudformationCalls', function() {
             return cloudformationCalls.updateStack(stackName, "FakeTEmplateBody", [])
                 .then(stack => {
                     expect(stack.StackName).to.equal(stackName);
-                    AWS.restore('CloudFormation');
                 });
         });
 
@@ -122,7 +117,6 @@ describe('cloudformationCalls', function() {
             return cloudformationCalls.updateStack(stackName, "FakeTemplateBody", [])
                 .then(stack => {
                     expect(stack.StackName).to.equal(stackName);
-                    AWS.restore('CloudFormation');
                 });
         });
 
@@ -137,7 +131,18 @@ describe('cloudformationCalls', function() {
                 })
                 .catch(err => {
                     expect(err.message).to.equal(message);
-                    AWS.restore('CloudFormation');
+                });
+        });
+    });
+
+    describe('deleteStack', function() {
+        it('should delete the stack', function() {
+            AWS.mock('CloudFormation', 'deleteStack', Promise.resolve({}));
+            AWS.mock('CloudFormation', 'waitFor', Promise.resolve({}));
+
+            return cloudformationCalls.deleteStack("FakeStack")
+                .then(result => {
+                    expect(result).to.be.true;
                 });
         });
     });

--- a/test/aws/cloudwatch-events-calls-test.js
+++ b/test/aws/cloudwatch-events-calls-test.js
@@ -13,6 +13,7 @@ describe('cloudWatchEventsCalls', function() {
 
     afterEach(function() {
         sandbox.restore();
+        AWS.restore('CloudWatchEvents');
     });
 
     describe('addTarget', function() {
@@ -26,4 +27,92 @@ describe('cloudWatchEventsCalls', function() {
                 });
         });
     });
+
+    describe('getTargets', function() {
+        it('should return targets if they exist', function() {
+            AWS.mock('CloudWatchEvents', 'listTargetsByRule', Promise.resolve({
+                Targets: []
+            }));
+
+            return cloudWatchEventsCalls.getTargets("FakeRule")
+                .then(targets => {
+                    expect(targets).to.deep.equal([]);
+                });
+        });
+    });
+
+    describe('getRule', function() {
+        it('should return the rule if it exists', function() {
+            let ruleName = "MyRule";
+            AWS.mock('CloudWatchEvents', 'listRules', Promise.resolve({
+                Rules: [{
+                    Name: ruleName
+                }]
+            }));
+
+            return cloudWatchEventsCalls.getRule(ruleName)
+                .then(rule => {
+                    expect(rule).to.not.be.null;
+                    expect(rule.Name).to.equal(ruleName);
+                });
+        });
+
+        it('should return null if the rule doesnt exist', function() {
+            let ruleName = "NonExistentRule";
+            AWS.mock('CloudWatchEvents', 'listRules', Promise.resolve({
+                Rules: []
+            }));
+
+            return cloudWatchEventsCalls.getRule(ruleName)
+                .then(rule => {
+                    expect(rule).to.be.null;
+                });
+        });
+    })
+
+    describe('removeTargets', function() {
+        it('should remove the requested targets', function() {
+            AWS.mock('CloudWatchEvents', 'removeTargets', Promise.resolve({
+                FailedEntryCount: 0
+            }));
+
+            let targets = [{
+                Id: "FakeId"
+            }];
+            return cloudWatchEventsCalls.removeTargets("FakeRule", targets)
+                .then(success => {
+                    expect(success).to.be.true;
+                });
+        });
+
+        it('should return false when some targets couldnt be removed', function() {
+            AWS.mock('CloudWatchEvents', 'removeTargets', Promise.resolve({
+                FailedEntryCount: 1
+            }));
+
+            let targets = [{
+                Id: "FakeId"
+            }];
+            return cloudWatchEventsCalls.removeTargets("FakeRule", targets)
+                .then(success => {
+                    expect(success).to.be.false;
+                });
+        });
+    });
+
+    describe('removeAllTargets', function() {
+        it('should remove all targets', function() {
+            let getTargetsStub = sandbox.stub(cloudWatchEventsCalls, 'getTargets').returns(Promise.resolve([{
+                Id: "FakeID"
+            }]));
+            let removeTargetsStub = sandbox.stub(cloudWatchEventsCalls, 'removeTargets').returns(Promise.resolve(true));
+
+            return cloudWatchEventsCalls.removeAllTargets("FakeRule")
+                .then(success => {
+                    expect(success).to.be.true;
+                    expect(getTargetsStub.calledOnce).to.be.true;
+                    expect(removeTargetsStub.calledOnce).to.be.true;
+                });
+        });
+    })
 });

--- a/test/aws/ec2-calls-test.js
+++ b/test/aws/ec2-calls-test.js
@@ -90,6 +90,37 @@ describe('ec2-calls', function () {
         });
     });
 
+    describe('removeAllIngressFromSg', function() {
+        it('should revoke all ingreess on the security group', function() {
+            let getSecurityGroupStub = sandbox.stub(ec2Calls, 'getSecurityGroup').returns(Promise.resolve({
+                GroupId: 'FakeId',
+                IpPermissions: [{
+                    IpProtocol: 'tcp',
+                    FromPort: 0,
+                    ToPort: 1024,
+                    UserIdGroupPairs: []
+                }]
+            }));
+            AWS.mock('EC2', 'revokeSecurityGroupIngress', Promise.resolve({}));
+
+            return ec2Calls.removeAllIngressFromSg("FakeGroup")
+                .then(success => {
+                    expect(success).to.be.true;
+                    expect(getSecurityGroupStub.calledOnce).to.be.true;
+                });
+        });
+
+        it('should return true if the security group has already been deleted', function() {
+            let getSecurityGroupStub = sandbox.stub(ec2Calls, 'getSecurityGroup').returns(Promise.resolve(null));
+
+            return ec2Calls.removeAllIngressFromSg("FakeGroup")
+                .then(success => {
+                    expect(success).to.be.true;
+                    expect(getSecurityGroupStub.calledOnce).to.be.true;
+                });
+        });
+    });
+
     describe('addIngressRuleToSgIfNotExists', function () {
         it('should add the ingress rule when it doesnt exist', function () {
             let sourceSg = {

--- a/test/cli/cli-test.js
+++ b/test/cli/cli-test.js
@@ -100,13 +100,32 @@ describe('cli module', function () {
     });
 
     describe('validateDeleteArgs', function() {
-        it('should throw an unimplemented error', function() {
-            try {
-                cli.validateDeleteArgs()
+        let handelFile = util.readYamlFileSync(`${__dirname}/../test-handel.yml`);
+        it('should fail if the -c param is not provided', function() {
+            let argv = {
+                e: "dev,prod"
             }
-            catch(e) {
-                expect(e.message).to.contain("DEPLOY ACTION IS NOT IMPLEMENTED");
+            let errors = cli.validateDeleteArgs(argv, handelFile);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain(`'-c' parameter is required`);
+        });
+
+        it('should fail if the -e parameter is not provided', function() {
+            let argv = {
+                c: `${__dirname}/../test-account-config.yml`
             }
+            let errors = cli.validateDeleteArgs(argv, handelFile);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain(`'-e' parameter is required`);
+        });
+
+        it('should succeed if all params are provided', function() {
+            let argv = {
+                e: "dev,prod",
+                c: `${__dirname}/../test-account-config.yml`
+            }
+            let errors = cli.validateDeleteArgs(argv, handelFile);
+            expect(errors.length).to.equal(0);
         });
     });
 });

--- a/test/datatypes/un-bind-context-test.js
+++ b/test/datatypes/un-bind-context-test.js
@@ -1,0 +1,14 @@
+const expect = require('chai').expect;
+const ServiceContext = require('../../lib/datatypes/service-context');
+const UnBindContext = require('../../lib/datatypes/un-bind-context');
+
+describe('UnBindContext', function() {
+    it('should be able to be constructed from a ServiceContext', function() {
+        let serviceContext = new ServiceContext('FakeApp', 'FakeEnv', 'FakeService', 'FakeType', '1', {});
+        let unBindContext = new UnBindContext(serviceContext);
+        expect(unBindContext.appName).to.equal(serviceContext.appName);
+        expect(unBindContext.environmentName).to.equal(serviceContext.environmentName);
+        expect(unBindContext.serviceName).to.equal(serviceContext.serviceName);
+        expect(unBindContext.serviceType).to.equal(serviceContext.serviceType);
+    });
+});

--- a/test/datatypes/un-deploy-context-test.js
+++ b/test/datatypes/un-deploy-context-test.js
@@ -1,0 +1,14 @@
+const expect = require('chai').expect;
+const ServiceContext = require('../../lib/datatypes/service-context');
+const UnDeployContext = require('../../lib/datatypes/un-deploy-context');
+
+describe('UnDeployContext', function() {
+    it('should be able to be constructed from a ServiceContext', function() {
+        let serviceContext = new ServiceContext('FakeApp', 'FakeEnv', 'FakeService', 'FakeType', '1', {});
+        let unDeployContext = new UnDeployContext(serviceContext);
+        expect(unDeployContext.appName).to.equal(serviceContext.appName);
+        expect(unDeployContext.environmentName).to.equal(serviceContext.environmentName);
+        expect(unDeployContext.serviceName).to.equal(serviceContext.serviceName);
+        expect(unDeployContext.serviceType).to.equal(serviceContext.serviceType);
+    });
+});

--- a/test/datatypes/un-pre-deploy-context-test.js
+++ b/test/datatypes/un-pre-deploy-context-test.js
@@ -1,0 +1,14 @@
+const expect = require('chai').expect;
+const ServiceContext = require('../../lib/datatypes/service-context');
+const UnPreDeployContext = require('../../lib/datatypes/un-pre-deploy-context');
+
+describe('UnDeployContext', function() {
+    it('should be able to be constructed from a ServiceContext', function() {
+        let serviceContext = new ServiceContext('FakeApp', 'FakeEnv', 'FakeService', 'FakeType', '1', {});
+        let unPreDeployContext = new UnPreDeployContext(serviceContext);
+        expect(unPreDeployContext.appName).to.equal(serviceContext.appName);
+        expect(unPreDeployContext.environmentName).to.equal(serviceContext.environmentName);
+        expect(unPreDeployContext.serviceName).to.equal(serviceContext.serviceName);
+        expect(unPreDeployContext.serviceType).to.equal(serviceContext.serviceType);
+    });
+});

--- a/test/handel-test.js
+++ b/test/handel-test.js
@@ -4,7 +4,11 @@ const bindLifecycle = require('../lib/lifecycle/bind');
 const deployLifecycle = require('../lib/lifecycle/deploy');
 const preDeployLifecycle = require('../lib/lifecycle/pre-deploy');
 const checkLifecycle = require('../lib/lifecycle/check');
+const unDeployLifecycle = require('../lib/lifecycle/un-deploy');
+const unPreDeployLifecycle = require('../lib/lifecycle/un-pre-deploy');
+const unBindLifecycle = require('../lib/lifecycle/un-bind');
 const PreDeployContext = require('../lib/datatypes/pre-deploy-context');
+const UnPreDeployContext = require('../lib/datatypes/un-pre-deploy-context');
 const util = require('../lib/util/util');
 const sinon = require('sinon');
 const expect = require('chai').expect;
@@ -36,6 +40,23 @@ describe('handel module', function() {
                     expect(preDeployServicesStub.calledTwice).to.be.true;
                     expect(bindServicesInLevelStub.callCount).to.equal(4);
                     expect(deployServicesInlevelStub.callCount).to.equal(4);
+                });
+        });
+    });
+
+    describe('delete', function() {
+        it('should delete the application environment', function() {
+            let unDeployServicesStub = sandbox.stub(unDeployLifecycle, 'unDeployServicesInLevel').returns({});
+            let unBindServicesStub = sandbox.stub(unBindLifecycle, 'unBindServicesInLevel').returns({});
+            let unPreDeployStub = sandbox.stub(unPreDeployLifecycle, 'unPreDeployServices').returns(Promise.resolve({
+                A: new UnPreDeployContext({})
+            }));
+            let handelFile = util.readYamlFileSync(`${__dirname}/test-handel.yml`);
+            return handel.delete(`${__dirname}/test-account-config.yml`, handelFile, "dev")
+                .then(results => {
+                    expect(unPreDeployStub.callCount).to.equal(1);
+                    expect(unBindServicesStub.callCount).to.equal(2);
+                    expect(unDeployServicesStub.callCount).to.equal(2);
                 });
         });
     });

--- a/test/lifecycle/un-pre-deploy-test.js
+++ b/test/lifecycle/un-pre-deploy-test.js
@@ -1,0 +1,56 @@
+const accountConfig = require('../../lib/util/account-config')(`${__dirname}/../test-account-config.yml`).getAccountConfig();
+const unPreDeployPhase = require('../../lib/lifecycle/un-pre-deploy');
+const EnvironmentContext = require('../../lib/datatypes/environment-context');
+const ServiceContext = require('../../lib/datatypes/service-context');
+const UnPreDeployContext = require('../../lib/datatypes/un-pre-deploy-context');
+const expect = require('chai').expect;
+
+describe('preDeploy', function() {
+    describe('preDeployServices', function() {
+        it('should execute predeploy on all services, even across levels', function() {
+            let serviceDeployers = {
+                efs: {
+                    unPreDeploy: function(serviceContext) {
+                        return Promise.resolve(new UnPreDeployContext(serviceContext));
+                    }
+                },
+                ecs: {
+                    unPreDeploy: function(serviceContext) {
+                        return Promise.resolve(new UnPreDeployContext(serviceContext));
+                    }
+                }
+            }
+
+            //Create EnvironmentContext
+            let appName = "test";
+            let deployVersion = "1";
+            let environmentName = "dev";
+            let environmentContext = new EnvironmentContext(appName, deployVersion, environmentName);
+
+            //Construct ServiceContext B
+            let serviceNameB = "B";
+            let serviceTypeB = "efs"
+            let paramsB = {
+                other: "param"
+            }
+            let serviceContextB = new ServiceContext(appName, environmentName, serviceNameB, serviceTypeB, deployVersion, paramsB);
+            environmentContext.serviceContexts[serviceNameB] = serviceContextB;
+
+            //Construct ServiceContext A
+            let serviceNameA = "A";
+            let serviceTypeA = "ecs";
+            let paramsA = {
+                some: "param",
+                dependencies: [ serviceNameB]
+            }
+            let serviceContextA = new ServiceContext(appName, environmentName, serviceNameA, serviceTypeA, deployVersion, paramsA);
+            environmentContext.serviceContexts[serviceNameA] = serviceContextA;
+
+            return unPreDeployPhase.unPreDeployServices(serviceDeployers, environmentContext)
+                .then(unPreDeployContexts => {
+                    expect(unPreDeployContexts[serviceNameA]).to.be.instanceof(UnPreDeployContext);
+                    expect(unPreDeployContexts[serviceNameB]).to.be.instanceof(UnPreDeployContext);
+                });
+        });
+    });
+});

--- a/test/services/apigateway/apigateway-test.js
+++ b/test/services/apigateway/apigateway-test.js
@@ -8,6 +8,9 @@ const BindContext = require('../../../lib/datatypes/bind-context');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 const deployersCommon = require('../../../lib/services/deployers-common');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
 
 describe('apigateway deployer', function() {
     let sandbox;
@@ -185,6 +188,39 @@ describe('apigateway deployer', function() {
                 })
                 .catch(err => {
                     expect(err.message).to.contain("API Gateway service doesn't produce events");
+                });
+        });
+    });
+
+    describe('unPreDeploy', function() {
+        it('should return an empty UnPreDeploy context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apigateway", "1", {});
+            return apigateway.unPreDeploy(serviceContext)
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                });
+        });
+    });
+
+    describe('unBind', function() {
+        it('should return an empty UnBind context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apigateway", "1", {});
+            return apigateway.unBind(serviceContext)
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                });
+        });
+    });
+
+    describe('unDeploy', function() {
+        it('should undeploy the stack', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apigateway", "1", {});
+            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+
+            return apigateway.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(unDeployStackStub.calledOnce).to.be.ture;
                 });
         });
     });

--- a/test/services/beanstalk/beanstalk-test.js
+++ b/test/services/beanstalk/beanstalk-test.js
@@ -7,6 +7,9 @@ const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
 const deployersCommon = require('../../../lib/services/deployers-common');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
@@ -152,6 +155,42 @@ describe('beanstalk deployer', function() {
                 })
                 .catch(err => {
                     expect(err.message).to.contain("Beanstalk service doesn't produce events");
+                });
+        });
+    });
+
+    describe('unPreDeploy', function() {
+        it('should delete the security group', function () {
+            let deleteSecurityGroupStub = sandbox.stub(deployersCommon, 'deleteSecurityGroupForService').returns(Promise.resolve(true));
+
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "beanstalk", "1", {});
+            return beanstalk.unPreDeploy(serviceContext)
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                    expect(deleteSecurityGroupStub.calledOnce).to.be.true;
+                });
+        });
+    });
+
+    describe('unBind', function() {
+        it('should return an empty UnBind context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "beanstalk", "1", {});
+            return beanstalk.unBind(serviceContext)
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                });
+        });
+    });
+
+    describe('unDeploy', function() {
+        it('should undeploy the stack', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "beanstalk", "1", {});
+            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+
+            return beanstalk.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(unDeployStackStub.calledOnce).to.be.ture;
                 });
         });
     });

--- a/test/services/dynamodb/dynamodb-test.js
+++ b/test/services/dynamodb/dynamodb-test.js
@@ -5,6 +5,10 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
+const deployersCommon = require('../../../lib/services/deployers-common');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
 const AWS = require('aws-sdk-mock');
 const sinon = require('sinon');
 const expect = require('chai').expect;
@@ -179,6 +183,39 @@ describe('dynamodb deployer', function() {
                 })
                 .catch(err => {
                     expect(err.message).to.contain("DynamoDB service doesn't produce events");
+                });
+        });
+    });
+
+        describe('unPreDeploy', function() {
+        it('should return an empty UnPreDeploy context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {});
+            return dynamodb.unPreDeploy(serviceContext)
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                });
+        });
+    });
+
+    describe('unBind', function() {
+        it('should return an empty UnBind context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {});
+            return dynamodb.unBind(serviceContext)
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                });
+        });
+    });
+
+    describe('unDeploy', function() {
+        it('should undeploy the stack', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "dynamodb", "1", {});
+            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+
+            return dynamodb.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(unDeployStackStub.calledOnce).to.be.ture;
                 });
         });
     });

--- a/test/services/lambda/lambda-test.js
+++ b/test/services/lambda/lambda-test.js
@@ -4,9 +4,12 @@ const cloudFormationCalls = require('../../../lib/aws/cloudformation-calls');
 const lambdaCalls = require('../../../lib/aws/lambda-calls');
 const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
 const ConsumeEventsContext = require('../../../lib/datatypes/consume-events-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
 const deployersCommon = require('../../../lib/services/deployers-common');
 const sinon = require('sinon');
 const expect = require('chai').expect;
@@ -268,6 +271,43 @@ describe('lambda deployer', function() {
                 })
                 .catch(err => {
                     expect(err.message).to.contain("Lambda service doesn't produce events");
+                });
+        });
+    });
+
+    describe('unPreDeploy', function() {
+        it('should return an empty UnPreDeployContext since it doesnt do anything', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return lambda.unPreDeploy(serviceContext)
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                    expect(unPreDeployContext.appName).to.equal(serviceContext.appName);
+                });
+        });
+    });
+
+    describe('unBind', function() {
+        it('should return an empty UnBindContext since it doesnt do anything', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return lambda.unBind(serviceContext)
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                    expect(unBindContext.appName).to.equal(serviceContext.appName);
+                });
+        });
+    });
+
+    describe('unDeploy', function() {
+        it('should delete the stack', function() {
+            let getStackStub = sandbox.stub(cloudFormationCalls, 'getStack').returns(Promise.resolve({}));
+            let deleteStackStub = sandbox.stub(cloudFormationCalls, 'deleteStack').returns(Promise.resolve(true));
+
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "FakeType", "1", {});
+            return lambda.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(getStackStub.calledOnce).to.be.true;
+                    expect(deleteStackStub.calledOnce).to.be.true;
                 });
         });
     });

--- a/test/services/s3/s3-test.js
+++ b/test/services/s3/s3-test.js
@@ -5,6 +5,10 @@ const ServiceContext = require('../../../lib/datatypes/service-context');
 const DeployContext = require('../../../lib/datatypes/deploy-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
+const deployersCommon = require('../../../lib/services/deployers-common');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
@@ -137,6 +141,39 @@ describe('s3 deployer', function() {
                 })
                 .catch(err => {
                     expect(err.message).to.contain("S3 service doesn't currently produce events");
+                });
+        });
+    });
+
+    describe('unPreDeploy', function() {
+        it('should return an empty UnPreDeploy context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3", "1", {});
+            return s3.unPreDeploy(serviceContext)
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                });
+        });
+    });
+
+    describe('unBind', function() {
+        it('should return an empty UnBind context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3", "1", {});
+            return s3.unBind(serviceContext)
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                });
+        });
+    });
+
+    describe('unDeploy', function() {
+        it('should undeploy the stack', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "s3", "1", {});
+            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+
+            return s3.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(unDeployStackStub.calledOnce).to.be.ture;
                 });
         });
     });

--- a/test/services/sns/sns-test.js
+++ b/test/services/sns/sns-test.js
@@ -7,6 +7,10 @@ const DeployContext = require('../../../lib/datatypes/deploy-context');
 const ProduceEventsContext = require('../../../lib/datatypes/produce-events-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
+const deployersCommon = require('../../../lib/services/deployers-common');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
@@ -201,6 +205,39 @@ describe('sns deployer', function() {
                     expect(err.message).to.contain('Unsupported event consumer type given');
                     expect(subscribeToTopicStub.notCalled).to.be.true;
                 })
+        });
+    });
+
+    describe('unPreDeploy', function() {
+        it('should return an empty UnPreDeploy context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sns", "1", {});
+            return sns.unPreDeploy(serviceContext)
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                });
+        });
+    });
+
+    describe('unBind', function() {
+        it('should return an empty UnBind context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sns", "1", {});
+            return sns.unBind(serviceContext)
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                });
+        });
+    });
+
+    describe('unDeploy', function() {
+        it('should undeploy the stack', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sns", "1", {});
+            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+
+            return sns.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(unDeployStackStub.calledOnce).to.be.ture;
+                });
         });
     });
 });

--- a/test/services/sqs/sqs-test.js
+++ b/test/services/sqs/sqs-test.js
@@ -7,6 +7,10 @@ const DeployContext = require('../../../lib/datatypes/deploy-context');
 const ConsumeEventsContext = require('../../../lib/datatypes/consume-events-context');
 const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
 const BindContext = require('../../../lib/datatypes/bind-context');
+const deployersCommon = require('../../../lib/services/deployers-common');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
 const sinon = require('sinon');
 const expect = require('chai').expect;
 
@@ -203,6 +207,39 @@ describe('sqs deployer', function() {
                 })
                 .catch(err => {
                     expect(err.message).to.contain("SQS service doesn't produce events");
+                });
+        });
+    });
+
+    describe('unPreDeploy', function() {
+        it('should return an empty UnPreDeploy context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sqs", "1", {});
+            return sqs.unPreDeploy(serviceContext)
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                });
+        });
+    });
+
+    describe('unBind', function() {
+        it('should return an empty UnBind context', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sqs", "1", {});
+            return sqs.unBind(serviceContext)
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                });
+        });
+    });
+
+    describe('unDeploy', function() {
+        it('should undeploy the stack', function() {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "sqs", "1", {});
+            let unDeployStackStub = sandbox.stub(deployersCommon, 'unDeployCloudFormationStack').returns(Promise.resolve(new UnDeployContext(serviceContext)));
+
+            return sqs.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                    expect(unDeployStackStub.calledOnce).to.be.ture;
                 });
         });
     });


### PR DESCRIPTION
This changes adds a delete lifecycle so you can execute 'handel delete'
to remove the cloudformation stacks for a particular environment.
The lifecycle is basically the reverse order of deploy. The unDeploy
comes first, followed by unBind, and unPreDeploy.

Resolves #32 