### PR TITLE
Add cleanup policy for uploaded S3 artifacts.

### DIFF
--- a/lib/aws/s3-calls.js
+++ b/lib/aws/s3-calls.js
@@ -2,8 +2,33 @@ const AWS = require('aws-sdk');
 const fs = require('fs');
 const winston = require('winston');
 
-exports.uploadFile = function(bucketName, key, filePath) {
-    let s3 = new AWS.S3({apiVersion: '2006-03-01'});
+function getObjectsToDelete(objects) {
+    let objectsToDelete = [];
+
+    //Sort by date
+    objects.sort(function(a,b) {
+        return b.LastModified.getTime() - a.LastModified.getTime();
+    });
+
+    //Always keep 5 most recent versions (no matter how old), then delete anything else older than 30 days
+    if(objects.length > 5) {
+        for(let i = 5; i < objects.length; i++) {
+            let object = objects[i];
+            let now = new Date();
+            var diff = Math.abs(now.getTime() - object.LastModified.getTime());
+            let daysOld = diff / (1000 * 60 * 60 * 24);
+            if(daysOld > 30) {
+                objectsToDelete.push(object);
+            }
+        }
+    }
+
+    return objectsToDelete;
+}
+
+
+exports.uploadFile = function (bucketName, key, filePath) {
+    let s3 = new AWS.S3({ apiVersion: '2006-03-01' });
     let fileStream = fs.createReadStream(filePath);
     let uploadParams = {
         Bucket: bucketName,
@@ -18,13 +43,65 @@ exports.uploadFile = function(bucketName, key, filePath) {
         });
 }
 
-exports.createBucket = function(bucketName, region) {
-    let s3 = new AWS.S3({apiVersion: '2006-03-01'});
+exports.listFilesByPrefix = function (bucketName, keyPrefix) {
+    let s3 = new AWS.S3({ apiVersion: '2006-03-01' });
+
+    var listParams = {
+        Bucket: bucketName,
+        MaxKeys: 1000,
+        Prefix: keyPrefix,
+    };
+    return s3.listObjectsV2(listParams).promise()
+        .then(listResponse => {
+            let objects = [];
+            if (listResponse.Contents) {
+                objects = listResponse.Contents;
+            }
+            return objects;
+        });
+}
+
+exports.deleteFiles = function(bucketName, objects) {
+    let s3 = new AWS.S3({ apiVersion: '2006-03-01' });
+
+    let objectsToDelete = [];
+    for(let object of objects) {
+        objectsToDelete.push({
+            Key: object.Key
+        });
+    }
+
+    var deleteParams = {
+        Bucket: bucketName,
+        Delete: {
+            Objects: objectsToDelete,
+            Quiet: true
+        }
+    };
+    return s3.deleteObjects(deleteParams).promise();
+}
+
+exports.cleanupOldVersionsOfFiles = function (bucketName, keyPrefix) {
+    return exports.listFilesByPrefix(bucketName, keyPrefix)
+        .then(objects => {
+            let objectsToDelete = getObjectsToDelete(objects);
+            if(objectsToDelete.length > 0) {
+                winston.info(`Deleting ${objectsToDelete.length} old versions older than 30 days`);
+                return exports.deleteFiles(bucketName, objectsToDelete);
+            }
+            else {
+                winston.info(`No artifacts older than 30 days to clean up`);
+            }
+        });
+}
+
+exports.createBucket = function (bucketName, region) {
+    let s3 = new AWS.S3({ apiVersion: '2006-03-01' });
     var createParams = {
         Bucket: bucketName,
         ACL: 'private'
     };
-    if(region !== 'us-east-1') { //If you specify us-east-1 it will fail (this is the default)
+    if (region !== 'us-east-1') { //If you specify us-east-1 it will fail (this is the default)
         createParams.CreateBucketConfiguration = {
             LocationConstraint: region
         }
@@ -38,14 +115,14 @@ exports.createBucket = function(bucketName, region) {
 }
 
 
-exports.getBucket = function(bucketName) {
-    let s3 = new AWS.S3({apiVersion: '2006-03-01'});
+exports.getBucket = function (bucketName) {
+    let s3 = new AWS.S3({ apiVersion: '2006-03-01' });
     winston.debug(`Getting S3 bucket ${bucketName}`)
     return s3.listBuckets().promise()
         .then(listResponse => {
             let buckets = listResponse.Buckets;
-            for(let bucket of buckets) {
-                if(bucket.Name === bucketName) {
+            for (let bucket of buckets) {
+                if (bucket.Name === bucketName) {
                     winston.debug(`Found bucket ${bucketName}`);
                     return bucket;
                 }
@@ -55,10 +132,10 @@ exports.getBucket = function(bucketName) {
         })
 }
 
-exports.createBucketIfNotExists = function(bucketName, region) {
+exports.createBucketIfNotExists = function (bucketName, region) {
     return exports.getBucket(bucketName)
         .then(bucket => {
-            if(bucket) {
+            if (bucket) {
                 return bucket;
             }
             else {

--- a/lib/services/deployers-common.js
+++ b/lib/services/deployers-common.js
@@ -188,10 +188,17 @@ exports.getRoutingInformationForService = function (serviceContext) {
 exports.uploadFileToHandelBucket = function (serviceContext, diskFilePath, s3FileName) {
     let bucketName = `handel-${accountConfig.region}-${accountConfig.account_id}`;
 
+    let artifactPrefix = `${serviceContext.appName}/${serviceContext.environmentName}/${serviceContext.serviceName}`;
+    let artifactKey = `${artifactPrefix}/${s3FileName}`;
     return s3Calls.createBucketIfNotExists(bucketName, accountConfig.region) //Ensure Handel bucket exists in this region
         .then(bucket => {
-            let artifactKey = `${serviceContext.appName}/${serviceContext.environmentName}/${serviceContext.serviceName}/${s3FileName}`;
-            return s3Calls.uploadFile(bucketName, artifactKey, diskFilePath);
+            return s3Calls.uploadFile(bucketName, artifactKey, diskFilePath)
+        })
+        .then(s3ObjectInfo => {
+            return s3Calls.cleanupOldVersionsOfFiles(bucketName, artifactPrefix)
+                .then(() => {
+                    return s3ObjectInfo;
+                });
         });
 }
 

--- a/test/services/deployers-common-test.js
+++ b/test/services/deployers-common-test.js
@@ -292,12 +292,14 @@ describe('deployers-common', function () {
 
             //Stub out dependent services
             let createBucketStub = sandbox.stub(s3Calls, 'createBucketIfNotExists').returns(Promise.resolve({}));
-            let uploadFileStub = sandbox.stub(s3Calls, 'uploadFile').returns({})
+            let uploadFileStub = sandbox.stub(s3Calls, 'uploadFile').returns({});
+            let cleanupOldVersionsStub = sandbox.stub(s3Calls, 'cleanupOldVersionsOfFiles').returns(Promise.resolve(null));
 
             return deployersCommon.uploadFileToHandelBucket(serviceContext, diskFilePath, s3FileName)
                 .then(s3ObjectInfo => {
                     expect(createBucketStub.calledOnce).to.be.true;
                     expect(uploadFileStub.calledOnce).to.be.true;
+                    expect(cleanupOldVersionsStub.calledOnce).to.be.true;
                     expect(s3ObjectInfo).to.deep.equal({});
                 });
         });


### PR DESCRIPTION
Handel's bucket where it stores deployable artifacts will now
only keep the last 5 versions, plus anything newer than 30 days.

Anything older than 30 days will be deleted on every deploy. The
most recent 5 versions will always be kept, however, regardless
of date

Resolves #49 
Resolves #86 