### PR TITLE
Add initial apiaccess service support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**/.DS_Store
 docs/_build
 out/
 node_modules/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ Handel is a library that orchestrates your AWS deployments so you don't have to
    :maxdepth: 1
    :caption: Supported Services
 
+   supported-services/apiaccess
    supported-services/apigateway
    supported-services/beanstalk
    supported-services/cloudwatchevents

--- a/docs/supported-services/apiaccess.rst
+++ b/docs/supported-services/apiaccess.rst
@@ -1,0 +1,64 @@
+.. _apiaccess:
+
+API Access
+==========
+This document contains information about the API Access service supported in Handel. This Handel service allows you to add read-only access to AWS services in your application.
+
+This service does not provision any AWS resources, it just serves to add additional permissions onto your applications.
+
+Parameters
+----------
+
+.. list-table::
+   :header-rows: 1
+
+   * - Parameter
+     - Type
+     - Required
+     - Default
+     - Description
+   * - aws_services
+     - List<string>
+     - Yes
+     - 
+     - A list of one or more AWS services for which to add permissions. See Supported Service Access below for the list of services you can specify.
+
+Supported Service Access
+~~~~~~~~~~~~~~~~~~~~~~~~
+The following AWS services are supported in the *aws_services* element:
+
+* organizations
+
+Example Handel File
+-------------------
+This Handel file shows an API Gateway service being configured with API access to the Organizations service
+
+.. code-block:: yaml
+
+    version: 1
+
+    name: my-apigateway-app
+
+    environments:
+      dev:
+        app:
+          type: apigateway
+          path_to_code: .
+          lambda_runtime: nodejs6.10
+          handler_function: index.handler
+        orgsaccess:
+          type: apiaccess
+          aws_services:
+          - organizations
+
+Depending on this service
+-------------------------
+You can reference this service as a dependency in other services. It does not export any environment variables. Instead, it will just add a policy on the dependent service to allow read access to the services you listed.
+
+Events produced by this service
+-------------------------------
+The API Access service does not produce events for other Handel services to consume.
+
+Events consumed by this service
+-------------------------------
+The API Access service does not consume events from other Handel services.

--- a/lib/services/apiaccess/index.js
+++ b/lib/services/apiaccess/index.js
@@ -1,0 +1,221 @@
+const winston = require('winston');
+const PreDeployContext = require('../../datatypes/pre-deploy-context');
+const BindContext = require('../../datatypes/bind-context');
+const DeployContext = require('../../datatypes/deploy-context');
+const fs = require('fs');
+const deployersCommon = require('../deployers-common');
+const UnPreDeployContext = require('../../datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../datatypes/un-bind-context');
+const UnDeployContext = require('../../datatypes/un-deploy-context');
+const util = require('../../util/util');
+
+function getDeployContext(serviceContext) {
+    let serviceParams = serviceContext.params;
+    let deployContext = new DeployContext(serviceContext);
+
+    //Inject policies
+    for (let service of serviceParams.aws_services) {
+        let statementsPath = `${__dirname}/${service}-statements.json`;
+        let serviceStatements = JSON.parse(util.readFileSync(statementsPath));
+        for(let serviceStatement of serviceStatements) {
+            deployContext.policies.push(serviceStatement);
+        }
+    }
+
+    return deployContext;
+}
+
+/**
+ * Checks the given service for required parameters and correctness. This provides
+ * a fail-fast mechanism for configuration errors before deploy is attempted.
+ *
+ * @param {ServiceContext} serviceContext - The ServiceContext for the service to check
+ * @returns {Array} - 0 or more String error messages
+ */
+exports.check = function (serviceContext) {
+    let errors = [];
+
+    let serviceParams = serviceContext.params;
+    if (!serviceParams.aws_services) {
+        errors.push("API Access - The 'aws_services' parameter is required.");
+    }
+    else {
+        for (let service of serviceParams.aws_services) {
+            let statementsPath = `${__dirname}/${service}-statements.json`;
+            if (!fs.existsSync(statementsPath)) {
+                errors.push(`API Access - The 'aws_service' value '${service}' is not supported`);
+            }
+        }
+    }
+
+    return errors;
+}
+
+
+/**
+ * Create resources needed for deployment that are also needed for dependency wiring
+ * with other services
+ *
+ * @param {ServiceContext} serviceContext - The ServiceContext for the service to check
+ * @returns {Promise.<PreDeployContext>} - A Promise of the PreDeployContext results from the pre-deploy
+ */
+exports.preDeploy = function (serviceContext) {
+    winston.info(`API Access - PreDeploy is not required for this service, skipping it`);
+    return Promise.resolve(new PreDeployContext(serviceContext));
+}
+
+
+/**
+ * Bind two resources from PreDeploy together by performing some wiring action on them. An example * is to add an ingress rule from one security group onto another. Wiring actions may also be
+ * performed in the Deploy phase if there isn't a two-way linkage. For example, security groups
+ * probably need to be done in PreDeploy and Bind, but environment variables from one service to
+ * another can just be done in Deploy
+ *
+ * Bind is run from the perspective of the service being consumed, not the other way around.
+ *
+ * Do not use this phase for creating resources. Those should be done either in PreDeploy or Deploy.
+ * This phase is for wiring up existing resources from PreDeploy
+ *
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being consumed
+ * @param {PreDeployContext} ownPreDeployContext - The PreDeployContext of the service being consumed
+ * @param {ServiceContext} dependentOfServiceContext - The ServiceContext of the service consuming this one
+ * @param {PreDeployContext} dependentOfPreDeployContext - The PreDeployContext of the service consuming this one
+ * @returns {Promise.<BindContext>} - A Promise of the BindContext results from the Bind
+ */
+exports.bind = function (ownServiceContext, ownPreDeployContext, dependentOfServiceContext, dependentOfPreDeployContext) {
+    winston.info(`API Access - Bind is not required for this service, skipping it`);
+    return Promise.resolve(new BindContext(ownServiceContext, dependentOfServiceContext));
+}
+
+
+/**
+ * Deploy the given resource, wiring it up with results from the DeployContexts of services
+ * that this one depends on. All dependencies are guaranteed to be deployed before the ones
+ * consuming them
+ *
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deployed
+ * @param {PreDeployContext} ownPreDeployContext - The PreDeployContext of the service being deployed
+ * @param {Array<DeployContext>} dependenciesDeployContexts - The DeployContexts of the services that this one depends on
+ * @returns {Promise.<DeployContext>} - A Promise of the DeployContext from this deploy
+ */
+exports.deploy = function (ownServiceContext, ownPreDeployContext, dependenciesDeployContexts) {
+    let stackName = deployersCommon.getResourceName(ownServiceContext);
+    winston.info(`API Access - Deploying api access ${stackName}`);
+
+    return Promise.resolve(getDeployContext(ownServiceContext))
+}
+
+/**
+ * In this phase, this service should make any changes necessary to allow it to consume events from the given source
+ * For example, a Lambda consuming events from an SNS topic should add a Lambda Function Permission to itself to allow
+ * the SNS ARN to invoke it.
+ * 
+ * Some events like DynamoDB -> Lambda will do all the work in here because Lambda uses a polling model to 
+ *   DynamoDB, so the DynamoDB service doesn't need to do any configuration itself. Most services will only do half
+ *   the work here, however, to grant permissions to the producing service. 
+ * 
+ * This method will only be called if your service is listed as an event consumer in another service's configuration.
+ * 
+ * Throw an exception in this method if your service doesn't consume any events at all.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service consuming events
+ * @param {DeployContext} ownDeployContext - The DeployContext of this service consuming events
+ * @param {ServiceContext} producerServiceContext - The ServiceContext of the service that will be producing events for this service
+ * @param {DeployContext} producerDeployContext - The DeployContext of the service that will be producing events for this service.
+ * @returns {Promise.<ConsumeEventsContext>} - The information about the event consumption for this service
+ */
+exports.consumeEvents = function (ownServiceContext, ownDeployContext, producerServiceContext, producerDeployContext) {
+    return Promise.reject(new Error("The API Access service doesn't consume events from other services"));
+}
+
+
+/**
+ * In this phase, this service should make any changes necessary to allow it to produce events to the consumer service.
+ * For example, an S3 bucket producing events to a Lambda should add the event notifications to the S3 bucket for the
+ * Lambda.
+ * 
+ * Some events, like DynamoDB -> Lambda, won't do any work here to produce events, because Lambda uses a polling
+ *   model. In cases like these, you can just return 
+ * 
+ * This method will only be called if your service has an event_consumers element in its configruation.
+ * 
+ * Throw an exception in this method if your service doesn't produce any events to any sources.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service producing events
+ * @param {DeployContext} ownDeployContext - The DeployContext of this service producing events
+ * @param {ServiceContext} producerServiceContext - The ServiceContext of the service that will be consuming events for this service
+ * @param {DeployContext} producerDeployContext - The DeployContext of the service that will be consuming events for this service.
+ * @returns {Promise.<ProduceEventsContext>} - The information about the event consumption for this service
+ */
+exports.produceEvents = function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
+    return Promise.reject(new Error("The API Access service doesn't currently produce events for other services"));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all resources created in PreDeploy.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of the service being deleted.
+ * @returns {Promise.<UnPreDeployContext>} - The UnPreDeployContext that represents the deletion of predeploy resources for this service
+ */
+exports.unPreDeploy = function (ownServiceContext) {
+    winston.info(`API Access - UnPreDeploy is not required for this service`);
+    return Promise.resolve(new UnPreDeployContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should remove all bindings on preDeploy resources.
+ * 
+ * Note that, unlike the Bind phase, this UnBind phase only takes a ServiceContext. Because the resource is being deleted, we
+ * don't need to execute UnBind for each event binding combination. Instead, we can just remove all bindings simultaneously in
+ * a single UnBind call.
+ * 
+ * @param {ServiceContext} ownServiceContext - The ServiceContext of this service being deleted
+ * @returns {Promise.<UnBindContext>} - The UnBindContext that represents the unbinding of this service.
+ */
+exports.unBind = function (ownServiceContext) {
+    winston.info(`API Access - UnBind is not required for this service`);
+    return Promise.resolve(new UnBindContext(ownServiceContext));
+}
+
+/**
+ * This phase is part of the delete lifecycle. In this phase, the service should delete itself.
+ * 
+ * Note that the delete lifecycle has no 'unConsumeEvents' or 'unProduceEvents'. In most cases, deleting the
+ * service will automatically delete any event bindings the service itself has, but in some cases this phase will
+ * also need to manually remove event bindings. An example of this is CloudWatch Events, which requires that
+ * you remove all targets before you can delete the service.
+ * 
+ * @param {ServiceContext} ownServiceContext = The ServiceContext of this service being deleted
+ * @returns {Promise.<UnDeployContext>} - The UnDeployContext that represents the deletion of this service
+ */
+exports.unDeploy = function (ownServiceContext) {
+    winston.info(`API Access - Nothing to delete for this service`);
+    return Promise.resolve(new UnDeployContext(ownServiceContext));
+}
+
+/**
+ * List of event sources this service can integrate with.
+ * 
+ * If the list is empty, this service cannot produce events to other services.
+ */
+exports.producedEventsSupportedServices = [];
+
+/**
+ * The list of output types that this service produces. 
+ * 
+ * If the list is empty, this service cannot be consumed by other resources.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.producedDeployOutputTypes = [
+    'policies'
+];
+
+/**
+ * The list of output types that this service consumes from other dependencies.
+ * 
+ * If the list is empty, this service cannot consume other services.
+ * 
+ * Valid list values: environmentVariables, scripts, policies, credentials, securityGroups
+ */
+exports.consumedDeployOutputTypes = [];

--- a/lib/services/apiaccess/organizations-statements.json
+++ b/lib/services/apiaccess/organizations-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "organizations:Get*",
+            "organizations:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "handel",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Simple orchestration of your AWS deployments",
   "main": "lib/handel.js",
   "scripts": {

--- a/test/services/apiaccess/apiaccess-test.js
+++ b/test/services/apiaccess/apiaccess-test.js
@@ -1,0 +1,133 @@
+const accountConfig = require('../../../lib/util/account-config')(`${__dirname}/../../test-account-config.yml`).getAccountConfig();
+const apiaccess = require('../../../lib/services/apiaccess');
+const ServiceContext = require('../../../lib/datatypes/service-context');
+const DeployContext = require('../../../lib/datatypes/deploy-context');
+const PreDeployContext = require('../../../lib/datatypes/pre-deploy-context');
+const BindContext = require('../../../lib/datatypes/bind-context');
+const UnPreDeployContext = require('../../../lib/datatypes/un-pre-deploy-context');
+const UnBindContext = require('../../../lib/datatypes/un-bind-context');
+const UnDeployContext = require('../../../lib/datatypes/un-deploy-context');
+const sinon = require('sinon');
+const expect = require('chai').expect;
+
+describe('apiaccess deployer', function () {
+    let sandbox;
+
+    beforeEach(function () {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    describe('check', function () {
+        it('should require the aws_services parameter', function () {
+            let serviceContext = {
+                params: {}
+            }
+            let errors = apiaccess.check(serviceContext);
+            expect(errors.length).to.equal(1);
+            expect(errors[0]).to.contain("'aws_services' parameter is required");
+        });
+
+        it('should require the provided aws_services to be from the supported list', function () {
+
+        });
+
+        it('should work when there are no configuration errors', function () {
+
+        });
+    });
+
+    describe('preDeploy', function () {
+        it('should return an empty predeploy context', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {});
+            return apiaccess.preDeploy(serviceContext)
+                .then(preDeployContext => {
+                    expect(preDeployContext).to.be.instanceof(PreDeployContext);
+                });
+        });
+    });
+
+    describe('bind', function () {
+        it('should return an empty bind context', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {});
+            return apiaccess.bind(serviceContext)
+                .then(bindContext => {
+                    expect(bindContext).to.be.instanceof(BindContext);
+                });
+        });
+    });
+
+    describe('deploy', function () {
+        it('should return a deploy context with the given policies', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {
+                aws_services: [
+                    "organizations"
+                ]
+            });
+            let preDeployContext = new PreDeployContext(serviceContext);
+
+            return apiaccess.deploy(serviceContext, preDeployContext, [])
+                .then(deployContext => {
+                    expect(deployContext).to.be.instanceof(DeployContext);
+                    expect(deployContext.policies.length).to.equal(1);
+                });
+        });
+    });
+
+    describe('consumeEvents', function () {
+        it('should return an error since it cant consume events', function () {
+            return apiaccess.consumeEvents(null, null, null, null)
+                .then(() => {
+                    expect(true).to.be.false; //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("API Access service doesn't consume events");
+                });
+        });
+    });
+
+    describe('produceEvents', function () {
+        it('should return an error since it doesnt yet produce events', function () {
+            return apiaccess.produceEvents(null, null, null, null)
+                .then(() => {
+                    expect(true).to.be.false; //Should not get here
+                })
+                .catch(err => {
+                    expect(err.message).to.contain("API Access service doesn't currently produce");
+                });
+        });
+    });
+
+    describe('unPreDeploy', function () {
+        it('should return an empty UnPreDeploy context', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {});
+            return apiaccess.unPreDeploy(serviceContext)
+                .then(unPreDeployContext => {
+                    expect(unPreDeployContext).to.be.instanceof(UnPreDeployContext);
+                });
+        });
+    });
+
+    describe('unBind', function () {
+        it('should return an empty UnBind context', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {});
+            return apiaccess.unBind(serviceContext)
+                .then(unBindContext => {
+                    expect(unBindContext).to.be.instanceof(UnBindContext);
+                });
+        });
+    });
+
+    describe('unDeploy', function () {
+        it('should return an empty UnDeployContext', function () {
+            let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {});
+            return apiaccess.unDeploy(serviceContext)
+                .then(unDeployContext => {
+                    expect(unDeployContext).to.be.instanceof(UnDeployContext);
+                });
+        });
+    });
+});


### PR DESCRIPTION
This service allows you to grant read-only access to AWS services
in an application. The service doesnt create any resources, it only
returns policy statements for consumption by other Handel services.

The initial service only supports the organizations service. More
can be added as needed.

Resolves #87 