### PR TITLE
Add more policies to apiaccess service type

### DIFF
--- a/docs/supported-services/apiaccess.rst
+++ b/docs/supported-services/apiaccess.rst
@@ -6,6 +6,14 @@ This document contains information about the API Access service supported in Han
 
 This service does not provision any AWS resources, it just serves to add additional permissions onto your applications.
 
+.. NOTE::
+
+    This service won't grant you permissions to publish to topics, read from data stores, etc. The permissions this service grants are read-only on the service level.
+
+    As an example of how you would use this service, you may want to run a Lambda that inspects your EC2 instances to audit them for certain characteristics. You can use this *apiaccess* service to grant that read-only access to EC2 to give you that information. 
+    
+    Since this service provides limited read-only access, in the EC2 exammple you would not be able to do things like start instances, create AMIs, etc.
+
 Parameters
 ----------
 
@@ -27,7 +35,25 @@ Supported Service Access
 ~~~~~~~~~~~~~~~~~~~~~~~~
 The following AWS services are supported in the *aws_services* element:
 
+* beanstalk
+* cloudformation
+* cloudwatchevents
+* codebuild
+* codepipeline
+* dynamodb
+* ec2
+* ecs
+* efs
+* elasticache
+* lambda
+* loadbalancing
 * organizations
+* rds
+* route53
+* s3
+* sns
+* sqs
+* ssm
 
 Example Handel File
 -------------------

--- a/lib/services/apiaccess/beanstalk-statements.json
+++ b/lib/services/apiaccess/beanstalk-statements.json
@@ -1,0 +1,14 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "elasticbeanstalk:Describe*",
+            "elasticbeanstalk:List*",
+            "elasticbeanstalk:RequestEnvironmentInfo",
+            "elasticbeanstalk:RetrieveEnvironmentInfo"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/cloudformation-statements.json
+++ b/lib/services/apiaccess/cloudformation-statements.json
@@ -1,0 +1,13 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "cloudformation:Describe*",
+            "cloudformation:Get*",
+            "cloudformation:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/cloudwatchevents-statements.json
+++ b/lib/services/apiaccess/cloudwatchevents-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "events:Describe*",
+            "events:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/codebuild-statements.json
+++ b/lib/services/apiaccess/codebuild-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "codebuild:BatchGet*",
+            "codebuild:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/codepipeline-statements.json
+++ b/lib/services/apiaccess/codepipeline-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "codepipeline:Get*",
+            "codepipeline:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/dynamodb-statements.json
+++ b/lib/services/apiaccess/dynamodb-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "dynamodb:Describe*",
+            "dynamodb:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/ec2-statements.json
+++ b/lib/services/apiaccess/ec2-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "ec2:Describe*",
+            "ec2:Get*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/ecs-statements.json
+++ b/lib/services/apiaccess/ecs-statements.json
@@ -1,0 +1,15 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "ecr:Describe*",
+            "ecr:Get*",
+            "ecr:List*",
+            "ecs:Describe*",
+            "ecs:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/ecs-statements.json
+++ b/lib/services/apiaccess/ecs-statements.json
@@ -3,7 +3,6 @@
         "Effect": "Allow",
         "Action": [
             "ecr:Describe*",
-            "ecr:Get*",
             "ecr:List*",
             "ecs:Describe*",
             "ecs:List*"

--- a/lib/services/apiaccess/efs-statements.json
+++ b/lib/services/apiaccess/efs-statements.json
@@ -1,0 +1,11 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "elasticfilesystem:Describe*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/elasticache-statements.json
+++ b/lib/services/apiaccess/elasticache-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "elasticache:Describe*",
+            "elasticache:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/lambda-statements.json
+++ b/lib/services/apiaccess/lambda-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "lambda:Get*",
+            "lambda:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/loadbalancing-statements.json
+++ b/lib/services/apiaccess/loadbalancing-statements.json
@@ -1,0 +1,11 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "elasticloadbalancing:Describe*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/rds-statements.json
+++ b/lib/services/apiaccess/rds-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "rds:Describe*",
+            "rds:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/route53-statements.json
+++ b/lib/services/apiaccess/route53-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "route53:Get*",
+            "route53:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/s3-statements.json
+++ b/lib/services/apiaccess/s3-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "s3:GetBucket*",
+            "s3:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/sns-statements.json
+++ b/lib/services/apiaccess/sns-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "sns:Get*",
+            "sns:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/sqs-statements.json
+++ b/lib/services/apiaccess/sqs-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "sqs:Get*",
+            "sqs:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/lib/services/apiaccess/ssm-statements.json
+++ b/lib/services/apiaccess/ssm-statements.json
@@ -1,0 +1,12 @@
+[
+    {
+        "Effect": "Allow",
+        "Action": [
+            "ssm:Describe*",
+            "ssm:List*"
+        ],
+        "Resource": [
+            "*"
+        ]
+    }
+]

--- a/test/phases/produce-events-test.js
+++ b/test/phases/produce-events-test.js
@@ -39,13 +39,13 @@ describe('produceEvents module', function () {
         it('should execute produceEvents on all services that specify themselves as producers for other services', function () {
             let serviceDeployers = {
                 lambda: {
-                    produceEvents: function (ownServiceContext,  ownDeployContext,  consumerServiceContext,  consumerDeployContext) {
+                    produceEvents: function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
                         return Promise.reject(new Error("Lambda doesn't produce events"));
 
                     }
                 },
                 s3: {
-                    produceEvents: function (ownServiceContext,  ownDeployContext,  consumerServiceContext,  consumerDeployContext) {
+                    produceEvents: function (ownServiceContext, ownDeployContext, consumerServiceContext, consumerDeployContext) {
                         return Promise.resolve(new ProduceEventsContext(ownServiceContext, consumerServiceContext));
                     }
                 }

--- a/test/services/apiaccess/apiaccess-test.js
+++ b/test/services/apiaccess/apiaccess-test.js
@@ -80,7 +80,8 @@ describe('apiaccess deployer', function () {
         it('should return a deploy context with the given policies', function () {
             let serviceContext = new ServiceContext("FakeApp", "FakeEnv", "FakeService", "apiaccess", "1", {
                 aws_services: [
-                    "organizations"
+                    "organizations",
+                    "ec2"
                 ]
             });
             let preDeployContext = new PreDeployContext(serviceContext);
@@ -88,7 +89,7 @@ describe('apiaccess deployer', function () {
             return apiaccess.deploy(serviceContext, preDeployContext, [])
                 .then(deployContext => {
                     expect(deployContext).to.be.instanceof(DeployContext);
-                    expect(deployContext.policies.length).to.equal(1);
+                    expect(deployContext.policies.length).to.equal(2);
                 });
         });
     });


### PR DESCRIPTION
This change adds more policies to the apiaccess service. This
service grants apps read-only permissions to introspect certain
services in their AWS accounts. This is useful for things like
Lambdas that audit resources in the AWS account.

Resolves #136 